### PR TITLE
Fix a couple of typos

### DIFF
--- a/R/as-casette.R
+++ b/R/as-casette.R
@@ -5,7 +5,7 @@
 #' can be coerced to a cassette
 #' @param ... further arguments passed on to [cassettes()] or
 #' [read_cassette_meta()
-#' @return a casette of class `Cassette`
+#' @return a cassette of class `Cassette`
 #' @examples \dontrun{
 #' vcr_configure(dir = tempfile())
 #' insert_cassette("foobar")

--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -71,7 +71,7 @@
 #'       Coming soon.
 #'     }
 #'     \item{\code{serialize_to_crul}}{
-#'       Serialize interaction on disk/casette to a \code{crul} response
+#'       Serialize interaction on disk/cassette to a \code{crul} response
 #'     }
 #'   }
 #' @format NULL
@@ -278,10 +278,10 @@ Cassette <- R6::R6Class(
       }
       # allow http interactions - disallow at end of call_block() below
       webmockr::webmockr_allow_net_connect()
-      
+
       # FIXME: temporary attempt to make it work: turn on mocking for httr
       webmockr::httr_mock()
-      
+
       # evaluate request
       resp <- lazyeval::lazy_eval(tmp)
       # disallow http interactions - allow at start of call_block() above

--- a/R/http_interaction_list.R
+++ b/R/http_interaction_list.R
@@ -46,7 +46,7 @@ NullList <- R6::R6Class(
 #' \strong{Private Methods}
 #'  \describe{
 #'     \item{\code{has_unused_interactions()}}{
-#'       Are there areny unused interactions? returns boolean
+#'       Are there any unused interactions? returns boolean
 #'     }
 #'     \item{\code{matching_interaction_index_for()}}{
 #'       asdfadf

--- a/R/request_handler.R
+++ b/R/request_handler.R
@@ -20,7 +20,7 @@
 #'     }
 #'     \item{\code{should_ignore()}}{
 #'       should we ignore the request, depends on request ignorer
-#'       infrastructure that's not workking yet
+#'       infrastructure that's not working yet
 #'     }
 #'     \item{\code{has_response_stub()}}{
 #'       Check if there is a matching response stub in the

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -51,7 +51,7 @@
 #' but you don't get an object back
 #'
 #' @section Cassettes on disk:
-#' Note that _"eject"_ only means that the R sesion cassette is no longer
+#' Note that _"eject"_ only means that the R session cassette is no longer
 #' in use. If any interactions were recorded to disk, then there is a file
 #' on disk with those interactions.
 #'

--- a/R/vcr-package.R
+++ b/R/vcr-package.R
@@ -12,7 +12,7 @@
 #' have been done. Check out that GitHub repo for all the details on
 #' how the canonical version works.
 #'
-#' @section Main funcitons:
+#' @section Main functions:
 #' The [use_cassette] function is most likely what you'll want to use. It
 #' sets the cassette you want to record to, inserts the cassette, and then
 #' ejects the cassette, recording the interactions to the cassette.

--- a/README.Rmd
+++ b/README.Rmd
@@ -62,7 +62,7 @@ system.time(
 unlink(file.path(cassette_path(), "helloworld.yml"))
 ```
 
-Importantly, your unit test deals with the same inputs and the same outputs - but behind the scenes you use a cached HTTP resonse - thus, your tests run faster.
+Importantly, your unit test deals with the same inputs and the same outputs - but behind the scenes you use a cached HTTP response - thus, your tests run faster.
 
 The cached response looks something like (condensed for brevity):
 
@@ -229,7 +229,7 @@ We set the following defaults:
 * `vcr_logging_opts` = `list()`
 
 
-You can get the defaults programatically with
+You can get the defaults programmatically with
 
 ```r
 vcr_config_defaults()

--- a/man/Cassette.Rd
+++ b/man/Cassette.Rd
@@ -85,7 +85,7 @@ Write metadata to disk.
 Coming soon.
 }
 \item{\code{serialize_to_crul}}{
-Serialize interaction on disk/casette to a \code{crul} response
+Serialize interaction on disk/cassette to a \code{crul} response
 }
 }
 }

--- a/man/HTTPInteractionList.Rd
+++ b/man/HTTPInteractionList.Rd
@@ -47,7 +47,7 @@ returns boolean
 \strong{Private Methods}
 \describe{
 \item{\code{has_unused_interactions()}}{
-Are there areny unused interactions? returns boolean
+Are there any unused interactions? returns boolean
 }
 \item{\code{matching_interaction_index_for()}}{
 asdfadf

--- a/man/RequestHandler.Rd
+++ b/man/RequestHandler.Rd
@@ -28,7 +28,7 @@ just returns FALSE
 }
 \item{\code{should_ignore()}}{
 should we ignore the request, depends on request ignorer
-infrastructure that's not workking yet
+infrastructure that's not working yet
 }
 \item{\code{has_response_stub()}}{
 Check if there is a matching response stub in the

--- a/man/RequestHandlerCrul.Rd
+++ b/man/RequestHandlerCrul.Rd
@@ -29,7 +29,7 @@ just returns FALSE
 }
 \item{\code{should_ignore()}}{
 should we ignore the request, depends on request ignorer
-infrastructure that's not workking yet
+infrastructure that's not working yet
 }
 \item{\code{has_response_stub()}}{
 Check if there is a matching response stub in the

--- a/man/RequestHandlerHttr.Rd
+++ b/man/RequestHandlerHttr.Rd
@@ -29,7 +29,7 @@ just returns FALSE
 }
 \item{\code{should_ignore()}}{
 should we ignore the request, depends on request ignorer
-infrastructure that's not workking yet
+infrastructure that's not working yet
 }
 \item{\code{has_response_stub()}}{
 Check if there is a matching response stub in the

--- a/man/as.cassette.Rd
+++ b/man/as.cassette.Rd
@@ -17,7 +17,7 @@ can be coerced to a cassette}
 [read_cassette_meta()}
 }
 \value{
-a casette of class \code{Cassette}
+a cassette of class \code{Cassette}
 }
 \description{
 Coerce names, etc. to cassettes

--- a/man/use_cassette.Rd
+++ b/man/use_cassette.Rd
@@ -81,7 +81,7 @@ but you don't get an object back
 
 \section{Cassettes on disk}{
 
-Note that \emph{"eject"} only means that the R sesion cassette is no longer
+Note that \emph{"eject"} only means that the R session cassette is no longer
 in use. If any interactions were recorded to disk, then there is a file
 on disk with those interactions.
 }

--- a/man/vcr.Rd
+++ b/man/vcr.Rd
@@ -21,7 +21,7 @@ have been done. Check out that GitHub repo for all the details on
 how the canonical version works.
 }
 
-\section{Main funcitons}{
+\section{Main functions}{
 
 The \link{use_cassette} function is most likely what you'll want to use. It
 sets the cassette you want to record to, inserts the cassette, and then

--- a/vignettes/configuration.Rmd
+++ b/vignettes/configuration.Rmd
@@ -173,7 +173,7 @@ vcr_configure(uri_parser = "urltools::url_parse")
 Some HTTP servers are not well-behaved and respond with invalid data. Set 
 `preserve_exact_body_bytes` to `TRUE` to base64 encode the result body in 
 order to preserve the bytes exactly as-is. `vcr` does not do this by
-default, since base64-encoding the string removes the human readibility 
+default, since base64-encoding the string removes the human readability 
 of the cassette.
 
 ```{r}

--- a/vignettes/request_matching.Rmd
+++ b/vignettes/request_matching.Rmd
@@ -26,7 +26,7 @@ Request matching
 ================
 
 To match previously recorded requests, `vcr` has to try to match new 
-HTTP reqeusts to a previously recorded one. By default, we match on 
+HTTP requests to a previously recorded one. By default, we match on 
 HTTP method (e.g., `GET`) and URI (e.g., `http://foo.com`), following 
 Ruby's VCR gem.
 

--- a/vignettes/vcr_vignette.Rmd
+++ b/vignettes/vcr_vignette.Rmd
@@ -89,7 +89,7 @@ unlink(file.path(cassette_path(), "helloworld.yml"))
 ```
 
 Importantly, your unit test deals with the same inputs and the same outputs - 
-but behind the scenes you use a cached HTTP resonse - thus, your tests run faster.
+but behind the scenes you use a cached HTTP response - thus, your tests run faster.
 
 The cached response looks something like (condensed for brevity):
 


### PR DESCRIPTION
## Description

Hi @sckott, as I was using `vcr` for, soon to be submitted to rOpenSci, [`rromeo`](https://github.com/Rekyt/rromeo) package I noticed a coupled of typos in the documentation of `vcr`.
I found them using `devtools::spell_check()`

And I had a weird error when trying to render `README.Rmd` file. So maybe you should update it.