### PR TITLE
Cleanup a few stray test cassettes 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Record test suite 'HTTP' requests and replays them during
     real 'HTTP' responses on disk in 'cassettes'. Subsequent 'HTTP' requests
     matching any previous requests in the same 'cassette' use a cached
     'HTTP' response.
-Version: 0.4.1.94
+Version: 0.4.1.95
 Authors@R: c(person("Scott", "Chamberlain", role = c("aut", "cre"),
     email = "sckott@protonmail.com", 
     comment = c(ORCID="0000-0003-1444-9135")),

--- a/tests/testthat/test-RequestIgnorer.R
+++ b/tests/testthat/test-RequestIgnorer.R
@@ -53,7 +53,7 @@ test_that("RequestIgnorer usage: w/ real requests", {
   req <- list(
     url = list(url = "http://127.0.0.1"),
     headers = NULL,
-    method = "get", 
+    method = "get",
     options = list(httpget = TRUE, useragent = "crul/0.5.4")
   )
   req$url$handle <- curl::new_handle()
@@ -76,7 +76,16 @@ test_that("RequestIgnorer usage: w/ real requests", {
 
 test_that("RequestIgnorer usage: w/ vcr_configure() usage", {
   skip_on_cran()
-  
+
+  on.exit({
+    files <- c(
+      "test_ignore_host.yml",
+      "test_ignore_host_ignored.yml",
+      "test_ignore_localhost_ignored.yml",
+      "test_ignore_localhost.yml")
+    unlink(file.path(vcr_configuration()$dir, files))
+  })
+
   library(crul)
 
   # IGNORE BY HOST


### PR DESCRIPTION
For some reason failing to cleanup these cassettes was causing 2 tests to fail *only* when running *Build > Check Package*  w/ RStudio. See log for test failures.

<details>
> library("testthat")
> library('vcr')
> test_check("vcr")
── 1. Failure: cassettes works (@test-cassettes.R#8)  ──────────────────────────────────────────
length(aa) not equal to 0.
1/1 mismatches
[1] 2 - 0 == 2

── 2. Failure: cassettes works (@test-cassettes.R#14)  ─────────────────────────────────────────
Names of `bb` ('foobar24', 'test_ignore_host', 'test_ignore_host_ignored') don't match 'foobar24'

══ testthat results  ═══════════════════════════════════════════════════════════════════════════
[ OK: 710 | SKIPPED: 3 | WARNINGS: 0 | FAILED: 2 ]
1. Failure: cassettes works (@test-cassettes.R#8) 
2. Failure: cassettes works (@test-cassettes.R#14) 
</details>