### PR TITLE
Cassette config inheritance

### DIFF
--- a/R/configuration.R
+++ b/R/configuration.R
@@ -1,34 +1,17 @@
-#' Configuration
+#' Global Configuration Options
 #'
-#' Optional settings to customize vcr's default behavior.
+#' Configurable options that define vcr's default behavior.
 #'
 #' @param ... configuration settings used to override defaults. See below for a
 #'   complete list of valid arguments.
 #'
 #' @section Configurable settings:
 #'
-#' ## Casstte options
+#' ## vcr options
+#'
+#' ### File locations
 #'
 #' - `dir` Cassette directory
-#' - `record` (character) One of 'all', 'none', 'new_episodes', or 'once'.
-#' See [recording]
-#' - `match_requests_on` vector of matchers. Default: (`method`, `uri`)
-#' See [request-matching] for details.
-#' - `cassettes` (list) don't use
-#' - `linked_context` (logical) linked context
-#'
-#' ## Recordings
-#'
-#' - `serialize_with`: (character) only option is "yaml"
-#' - `persist_with` (character) only option is "FileSystem"
-#' - `uri_parser` the uri parser, default: [crul::url_parse()]
-#' - `preserve_exact_body_bytes` (logical) preserve exact body bytes for
-#' - `turned_off` (logical) VCR is turned on by default. Default:
-#' `FALSE`
-#' - `re_record_interval` (numeric) When given, the cassette will be
-#' re-recorded at the given interval, in seconds.
-#' - `clean_outdated_http_interactions` (logical) Should outdated interactions
-#' be recorded back to file. Default: `FALSE`
 #' - `write_disk_path` (character) path to write files to
 #' for any requests that write responses to disk. by default this parameter
 #' is `NULL`. For testing a package, you'll probably want this path to
@@ -36,8 +19,10 @@
 #' directory, e.g., where your cassettes are in `tests/fixtures`, your
 #' files from requests that write to disk are in `tests/files`
 #'
-#' ## Connectivity
+#' ### Contexts
 #'
+#' - `turned_off` (logical) VCR is turned on by default. Default:
+#' `FALSE`
 #' - `allow_unused_http_interactions` (logical) Default: `TRUE`
 #' - `allow_http_connections_when_no_cassette` (logical) Determines how vcr
 #' treats HTTP requests that are made when no vcr cassette is in use. When
@@ -45,30 +30,57 @@
 #' When `FALSE` (default), an [UnhandledHTTPRequestError] error will be raised
 #' for any HTTP request made when there is no cassette in use
 #'
-#' ## Logging
-#'
-#' - `log` (logical) should we log important vcr things? Default: `FALSE`
-#' - `log_opts` (list) Additional logging options. Options include:
-#'   - file: one of a file path to log to or "console"
-#'   - log_prefix: default: "Cassette". We insert the cassette name after
-#'     that prefix, then the rest of the message
-#'   - More to come...
-#'
-#' ## Filtering
+#' ### Filtering
 #'
 #' - `ignore_hosts` (character) Vector of hosts to ignore. e.g., localhost, or
 #' google.com. These hosts are ignored and real HTTP requests allowed to go
 #' through
 #' - `ignore_localhost` (logical) Default: `FALSE`
 #' - `ignore_request` List of requests to ignore. NOT USED RIGHT NOW, sorry
-#' - `filter_sensitive_data` (list) named list of values to replace. format
-#' is: `list(thing_to_replace_it_with = thing_to_replace)`. We replace all
-#' instances of `thing_to_replace` with `thing_to_replace_it_with`. Before
-#' recording (writing to a cassette) we do the replacement and then when
-#' reading from the cassette we do the reverse replacement to get back
-#' to the real data. Before record replacement happens in internal
-#' function `write_interactions()`, while before playback replacement
-#' happens in internal function `YAML$deserialize_path()`
+#' - `filter_sensitive_data` named list of values to replace. Format is:
+#'   ```
+#'   list(thing_to_replace_it_with = thing_to_replace)
+#'   ```
+#'   We replace all instances of `thing_to_replace` with
+#' `thing_to_replace_it_with`. Before recording (writing to a cassette) we do
+#' the replacement and then when reading from the cassette we do the reverse
+#' replacement to get back to the real data. Before record replacement happens
+#' in internal function `write_interactions()`, while before playback
+#' replacement happens in internal function `YAML$deserialize_path()`
+#'
+#' ### Internals
+#'
+#' - `cassettes` (list) don't use
+#' - `linked_context` (logical) linked context
+#' - `uri_parser` the uri parser, default: [crul::url_parse()]
+#'
+#' ### Logging
+#'
+#' - `log` (logical) should we log important vcr things? Default: `FALSE`
+#' - `log_opts` (list) Additional logging options:
+#'   - `file` either `"console"` or a file path to log to
+#'   - `log_prefix` default: "Cassette". We insert the cassette name after
+#'     that prefix, then the rest of the message.
+#'   - More to come...
+#'
+#' ## Cassette Options
+#'
+#' These settings can be configured globally, using `vcr_configure()`, or
+#' locally, using either `use_cassette()` or `insert_cassette()`. Global
+#' settings are applied to *all* cassettes but are overridden by settings
+#' defined locally for individuall cassettes.
+#'
+#' - `record` (character) One of 'all', 'none', 'new_episodes', or 'once'.
+#' See [recording]
+#' - `match_requests_on` vector of matchers. Default: (`method`, `uri`)
+#' See [request-matching] for details.
+#' - `serialize_with`: (character) only option is "yaml"
+#' - `persist_with` (character) only option is "FileSystem"
+#' - `preserve_exact_body_bytes` (logical) preserve exact body bytes for
+#' - `re_record_interval` (numeric) When given, the cassette will be
+#' re-recorded at the given interval, in seconds.
+#' - `clean_outdated_http_interactions` (logical) Should outdated interactions
+#' be recorded back to file. Default: `FALSE`
 #'
 #'
 #' @examples
@@ -78,6 +90,7 @@
 #' vcr_config_defaults()
 #' vcr_configure(dir = tempdir(), ignore_hosts = "google.com")
 #' vcr_configure(dir = tempdir(), ignore_localhost = TRUE)
+#'
 #'
 #' # logging
 #' vcr_configure(dir = tempdir(), log = TRUE,

--- a/R/configuration.R
+++ b/R/configuration.R
@@ -288,7 +288,7 @@ VCRConfig <- R6::R6Class(
       preserve_exact_body_bytes = FALSE,
       turned_off = FALSE,
       re_record_interval = NULL,
-      clean_outdated_http_interactions = NULL,
+      clean_outdated_http_interactions = FALSE,
       allow_http_connections_when_no_cassette = FALSE,
       cassettes = list(),
       linked_context = NULL,

--- a/R/insert_cassette.R
+++ b/R/insert_cassette.R
@@ -24,12 +24,15 @@ vcr__env <- new.env()
 #' # cleanup
 #' unlink(file.path(tempdir(), "leo5.yml"))
 #' }
-insert_cassette <- function(name, record="once",
+insert_cassette <- function(name,
+  record = "once",
   match_requests_on = c('method', 'uri'),
-  update_content_length_header=FALSE,
-  allow_playback_repeats=FALSE, serialize_with="yaml",
-  persist_with="FileSystem",
-  preserve_exact_body_bytes=FALSE, re_record_interval = NULL,
+  update_content_length_header = FALSE,
+  allow_playback_repeats = FALSE,
+  serialize_with = "yaml",
+  persist_with = "FileSystem",
+  preserve_exact_body_bytes = FALSE,
+  re_record_interval = NULL,
   clean_outdated_http_interactions = FALSE) {
 
   check_cassette_name(name)
@@ -49,18 +52,22 @@ insert_cassette <- function(name, record="once",
     vcr__env$current_cassette <- name
 
     # make cassette
-    tmp <- Cassette$new(
-      name = name, record = record, match_requests_on = match_requests_on,
-      re_record_interval = re_record_interval, 
+    tmp <- Cassette$new(name,
+      record = record,
+      match_requests_on = match_requests_on,
+      re_record_interval = re_record_interval,
       clean_outdated_http_interactions = clean_outdated_http_interactions,
-      tag = NULL, tags = NULL,
+      tag = NULL,
+      tags = NULL,
       update_content_length_header = update_content_length_header,
       decode_compressed_response = NULL,
       allow_playback_repeats = allow_playback_repeats,
       allow_unused_http_interactions = NULL,
       exclusive = NULL,
-      serialize_with = serialize_with, persist_with = persist_with,
-      preserve_exact_body_bytes = preserve_exact_body_bytes)
+      serialize_with = serialize_with,
+      persist_with = persist_with,
+      preserve_exact_body_bytes = preserve_exact_body_bytes
+    )
     return(tmp)
   } else if (!light_switch$ignore_cassettes) {
     message <- "vcr is turned off.  You must turn it on before you can insert a cassette.

--- a/R/insert_cassette.R
+++ b/R/insert_cassette.R
@@ -4,6 +4,7 @@ vcr__env <- new.env()
 #'
 #' @export
 #' @inheritParams use_cassette
+#' @inheritSection use_cassette Cassette options
 #' @seealso [use_cassette()], [eject_cassette()]
 #' @return an object of class `Cassette`
 #' @examples \dontrun{

--- a/R/insert_cassette.R
+++ b/R/insert_cassette.R
@@ -25,15 +25,15 @@ vcr__env <- new.env()
 #' unlink(file.path(tempdir(), "leo5.yml"))
 #' }
 insert_cassette <- function(name,
-  record = "once",
-  match_requests_on = c('method', 'uri'),
+  record = NULL,
+  match_requests_on = NULL,
   update_content_length_header = FALSE,
   allow_playback_repeats = FALSE,
-  serialize_with = "yaml",
-  persist_with = "FileSystem",
-  preserve_exact_body_bytes = FALSE,
+  serialize_with = NULL,
+  persist_with = NULL,
+  preserve_exact_body_bytes = NULL,
   re_record_interval = NULL,
-  clean_outdated_http_interactions = FALSE) {
+  clean_outdated_http_interactions = NULL) {
 
   check_cassette_name(name)
   vcr_env_handle()
@@ -53,10 +53,10 @@ insert_cassette <- function(name,
 
     # make cassette
     tmp <- Cassette$new(name,
-      record = record,
-      match_requests_on = match_requests_on,
-      re_record_interval = re_record_interval,
-      clean_outdated_http_interactions = clean_outdated_http_interactions,
+      record = record %||% vcr_c$record,
+      match_requests_on = match_requests_on %||% vcr_c$match_requests_on,
+      re_record_interval = re_record_interval %||% vcr_c$re_record_interval,
+      clean_outdated_http_interactions = clean_outdated_http_interactions %||% vcr_c$clean_outdated_http_interactions,
       tag = NULL,
       tags = NULL,
       update_content_length_header = update_content_length_header,
@@ -64,9 +64,9 @@ insert_cassette <- function(name,
       allow_playback_repeats = allow_playback_repeats,
       allow_unused_http_interactions = NULL,
       exclusive = NULL,
-      serialize_with = serialize_with,
-      persist_with = persist_with,
-      preserve_exact_body_bytes = preserve_exact_body_bytes
+      serialize_with = serialize_with %||% vcr_c$serialize_with,
+      persist_with = persist_with %||% vcr_c$persist_with,
+      preserve_exact_body_bytes = preserve_exact_body_bytes %||% vcr_c$preserve_exact_body_bytes
     )
     return(tmp)
   } else if (!light_switch$ignore_cassettes) {

--- a/R/insert_cassette.R
+++ b/R/insert_cassette.R
@@ -56,18 +56,18 @@ insert_cassette <- function(name,
     tmp <- Cassette$new(name,
       record = record %||% vcr_c$record,
       match_requests_on = match_requests_on %||% vcr_c$match_requests_on,
+      update_content_length_header = update_content_length_header,
+      allow_playback_repeats = allow_playback_repeats,
+      serialize_with = serialize_with %||% vcr_c$serialize_with,
+      persist_with = persist_with %||% vcr_c$persist_with,
+      preserve_exact_body_bytes = preserve_exact_body_bytes %||% vcr_c$preserve_exact_body_bytes,
       re_record_interval = re_record_interval %||% vcr_c$re_record_interval,
       clean_outdated_http_interactions = clean_outdated_http_interactions %||% vcr_c$clean_outdated_http_interactions,
       tag = NULL,
       tags = NULL,
-      update_content_length_header = update_content_length_header,
       decode_compressed_response = NULL,
-      allow_playback_repeats = allow_playback_repeats,
       allow_unused_http_interactions = NULL,
-      exclusive = NULL,
-      serialize_with = serialize_with %||% vcr_c$serialize_with,
-      persist_with = persist_with %||% vcr_c$persist_with,
-      preserve_exact_body_bytes = preserve_exact_body_bytes %||% vcr_c$preserve_exact_body_bytes
+      exclusive = NULL
     )
     return(tmp)
   } else if (!light_switch$ignore_cassettes) {

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -152,13 +152,13 @@ use_cassette <- function(name, ...,
   cassette <- insert_cassette(name,
     record = record,
     match_requests_on = match_requests_on,
-    re_record_interval = re_record_interval,
-    clean_outdated_http_interactions = clean_outdated_http_interactions,
     update_content_length_header = update_content_length_header,
     allow_playback_repeats = allow_playback_repeats,
     serialize_with = serialize_with,
     persist_with = persist_with,
-    preserve_exact_body_bytes = preserve_exact_body_bytes
+    preserve_exact_body_bytes = preserve_exact_body_bytes,
+    re_record_interval = re_record_interval,
+    clean_outdated_http_interactions = clean_outdated_http_interactions
   )
   if (is.null(cassette)) {
     force(...)

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -43,9 +43,9 @@
 #'
 #' @section Cassette options:
 #'
-#' Note the default values for arguments controlling cassette behavior are
+#' Default values for arguments controlling cassette behavior are
 #' inherited from vcr's global configuration. See [`vcr_configure()`] for a
-#' complete list of options and their default values. You can override these
+#' complete list of options and their default settings. You can override these
 #' options for a specific cassette by changing an argument's value to something
 #' other than `NULL` when calling either `insert_cassette()` or
 #' `use_cassette()`.

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -3,11 +3,11 @@
 #' @export
 #' @param name The name of the cassette. vcr will sanitize this to ensure it
 #' is a valid file name.
-#' @param ... a block of code to evalulate, wrapped in curly braces. required.
-#' if you don't pass a code block you'll get a stop message. if you can't pass
-#' a code block use instead [insert_cassette()]
-#' @param record The record mode. Default: "once". In the future we'll support
-#' "once", "all", "none", "new_episodes". See [recording] for more information
+#' @param ... a block of code containing one or more requests (required). Use
+#' curly braces to encapsulate multi-line code blocks. If you can't pass a code
+#' block use [insert_cassette()] instead.
+#' @param record The record mode (default: `"once"`). See [recording] for a
+#' complete list of the different recording modes.
 #' @param match_requests_on List of request matchers
 #' to use to determine what recorded HTTP interaction to replay. Defaults to
 #' `["method", "uri"]`. The built-in matchers are "method", "uri", "host",

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -1,4 +1,4 @@
-#' Use a cassette
+#' Use a cassette to record HTTP requests
 #'
 #' @export
 #' @param name The name of the cassette. vcr will sanitize this to ensure it
@@ -40,6 +40,15 @@
 #' - `eject_cassette` ejects the current cassette. The cassette
 #'  will no longer be used. In addition, any newly recorded HTTP interactions
 #'  will be written to disk.
+#'
+#' @section Cassette options:
+#'
+#' Note the default values for arguments controlling cassette behavior are
+#' inherited from vcr's global configuration. See [`vcr_configure()`] for a
+#' complete list of options and their default values. You can override these
+#' options for a specific cassette by changing an argument's value to something
+#' other than `NULL` when calling either `insert_cassette()` or
+#' `use_cassette()`.
 #'
 #' @section Behavior:
 #' This function handles a few different scenarios:

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -130,26 +130,26 @@
 #' }
 
 use_cassette <- function(name, ...,
-  record = "once",
-  match_requests_on = c("method", "uri"),
+  record = NULL,
+  match_requests_on = NULL,
   update_content_length_header = FALSE,
   allow_playback_repeats = FALSE,
-  serialize_with = "yaml",
-  persist_with = "FileSystem",
-  preserve_exact_body_bytes = FALSE,
+  serialize_with = NULL,
+  persist_with = NULL,
+  preserve_exact_body_bytes = NULL,
   re_record_interval = NULL,
-  clean_outdated_http_interactions = FALSE) {
+  clean_outdated_http_interactions = NULL) {
 
   cassette <- insert_cassette(name,
     record = record,
     match_requests_on = match_requests_on,
     re_record_interval = re_record_interval,
-    clean_outdated_http_interactions = clean_outdated_http_interactions
+    clean_outdated_http_interactions = clean_outdated_http_interactions,
     update_content_length_header = update_content_length_header,
     allow_playback_repeats = allow_playback_repeats,
     serialize_with = serialize_with,
     persist_with = persist_with,
-    preserve_exact_body_bytes = preserve_exact_body_bytes,
+    preserve_exact_body_bytes = preserve_exact_body_bytes
   )
   if (is.null(cassette)) {
     force(...)

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -129,22 +129,28 @@
 #' two; res2
 #' }
 
-use_cassette <- function(name, ..., record = "once",
+use_cassette <- function(name, ...,
+  record = "once",
   match_requests_on = c("method", "uri"),
   update_content_length_header = FALSE,
   allow_playback_repeats = FALSE,
-  serialize_with = "yaml", persist_with = "FileSystem",
-  preserve_exact_body_bytes = FALSE, re_record_interval = NULL,
+  serialize_with = "yaml",
+  persist_with = "FileSystem",
+  preserve_exact_body_bytes = FALSE,
+  re_record_interval = NULL,
   clean_outdated_http_interactions = FALSE) {
 
-  cassette <- insert_cassette(
-    name, record = record, match_requests_on = match_requests_on,
+  cassette <- insert_cassette(name,
+    record = record,
+    match_requests_on = match_requests_on,
+    re_record_interval = re_record_interval,
+    clean_outdated_http_interactions = clean_outdated_http_interactions
     update_content_length_header = update_content_length_header,
     allow_playback_repeats = allow_playback_repeats,
-    serialize_with = serialize_with, persist_with = persist_with,
+    serialize_with = serialize_with,
+    persist_with = persist_with,
     preserve_exact_body_bytes = preserve_exact_body_bytes,
-    re_record_interval = re_record_interval,
-    clean_outdated_http_interactions = clean_outdated_http_interactions)
+  )
   if (is.null(cassette)) {
     force(...)
     return(NULL)

--- a/man/insert_cassette.Rd
+++ b/man/insert_cassette.Rd
@@ -21,8 +21,8 @@ insert_cassette(
 \item{name}{The name of the cassette. vcr will sanitize this to ensure it
 is a valid file name.}
 
-\item{record}{The record mode. Default: "once". In the future we'll support
-"once", "all", "none", "new_episodes". See \link{recording} for more information}
+\item{record}{The record mode (default: \code{"once"}). See \link{recording} for a
+complete list of the different recording modes.}
 
 \item{match_requests_on}{List of request matchers
 to use to determine what recorded HTTP interaction to replay. Defaults to
@@ -61,6 +61,17 @@ an object of class \code{Cassette}
 \description{
 Insert a cassette to record HTTP requests
 }
+\section{Cassette options}{
+
+
+Default values for arguments controlling cassette behavior are
+inherited from vcr's global configuration. See \code{\link[=vcr_configure]{vcr_configure()}} for a
+complete list of options and their default settings. You can override these
+options for a specific cassette by changing an argument's value to something
+other than \code{NULL} when calling either \code{insert_cassette()} or
+\code{use_cassette()}.
+}
+
 \examples{
 \dontrun{
 library(vcr)

--- a/man/insert_cassette.Rd
+++ b/man/insert_cassette.Rd
@@ -6,15 +6,15 @@
 \usage{
 insert_cassette(
   name,
-  record = "once",
-  match_requests_on = c("method", "uri"),
+  record = NULL,
+  match_requests_on = NULL,
   update_content_length_header = FALSE,
   allow_playback_repeats = FALSE,
-  serialize_with = "yaml",
-  persist_with = "FileSystem",
-  preserve_exact_body_bytes = FALSE,
+  serialize_with = NULL,
+  persist_with = NULL,
+  preserve_exact_body_bytes = NULL,
   re_record_interval = NULL,
-  clean_outdated_http_interactions = FALSE
+  clean_outdated_http_interactions = NULL
 )
 }
 \arguments{

--- a/man/use_cassette.Rd
+++ b/man/use_cassette.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/use_cassette.R
 \name{use_cassette}
 \alias{use_cassette}
-\title{Use a cassette}
+\title{Use a cassette to record HTTP requests}
 \usage{
 use_cassette(
   name,
@@ -22,12 +22,12 @@ use_cassette(
 \item{name}{The name of the cassette. vcr will sanitize this to ensure it
 is a valid file name.}
 
-\item{...}{a block of code to evalulate, wrapped in curly braces. required.
-if you don't pass a code block you'll get a stop message. if you can't pass
-a code block use instead \code{\link[=insert_cassette]{insert_cassette()}}}
+\item{...}{a block of code containing one or more requests (required). Use
+curly braces to encapsulate multi-line code blocks. If you can't pass a code
+block use \code{\link[=insert_cassette]{insert_cassette()}} instead.}
 
-\item{record}{The record mode. Default: "once". In the future we'll support
-"once", "all", "none", "new_episodes". See \link{recording} for more information}
+\item{record}{The record mode (default: \code{"once"}). See \link{recording} for a
+complete list of the different recording modes.}
 
 \item{match_requests_on}{List of request matchers
 to use to determine what recorded HTTP interaction to replay. Defaults to
@@ -64,7 +64,7 @@ interactions be recorded back to file? default: \code{FALSE}}
 an object of class \code{Cassette}
 }
 \description{
-Use a cassette
+Use a cassette to record HTTP requests
 }
 \details{
 A run down of the family of top level \pkg{vcr} functions
@@ -77,6 +77,17 @@ will no longer be used. In addition, any newly recorded HTTP interactions
 will be written to disk.
 }
 }
+\section{Cassette options}{
+
+
+Default values for arguments controlling cassette behavior are
+inherited from vcr's global configuration. See \code{\link[=vcr_configure]{vcr_configure()}} for a
+complete list of options and their default settings. You can override these
+options for a specific cassette by changing an argument's value to something
+other than \code{NULL} when calling either \code{insert_cassette()} or
+\code{use_cassette()}.
+}
+
 \section{Behavior}{
 
 This function handles a few different scenarios:

--- a/man/use_cassette.Rd
+++ b/man/use_cassette.Rd
@@ -7,15 +7,15 @@
 use_cassette(
   name,
   ...,
-  record = "once",
-  match_requests_on = c("method", "uri"),
+  record = NULL,
+  match_requests_on = NULL,
   update_content_length_header = FALSE,
   allow_playback_repeats = FALSE,
-  serialize_with = "yaml",
-  persist_with = "FileSystem",
-  preserve_exact_body_bytes = FALSE,
+  serialize_with = NULL,
+  persist_with = NULL,
+  preserve_exact_body_bytes = NULL,
   re_record_interval = NULL,
-  clean_outdated_http_interactions = FALSE
+  clean_outdated_http_interactions = NULL
 )
 }
 \arguments{

--- a/man/vcr_configure.Rd
+++ b/man/vcr_configure.Rd
@@ -5,7 +5,7 @@
 \alias{vcr_configure_reset}
 \alias{vcr_configuration}
 \alias{vcr_config_defaults}
-\title{Configuration}
+\title{Global Configuration Options}
 \usage{
 vcr_configure(...)
 
@@ -20,34 +20,14 @@ vcr_config_defaults()
 complete list of valid arguments.}
 }
 \description{
-Optional settings to customize vcr's default behavior.
+Configurable options that define vcr's default behavior.
 }
 \section{Configurable settings}{
 
-\subsection{Casstte options}{
+\subsection{vcr options}{
+\subsection{File locations}{
 \itemize{
 \item \code{dir} Cassette directory
-\item \code{record} (character) One of 'all', 'none', 'new_episodes', or 'once'.
-See \link{recording}
-\item \code{match_requests_on} vector of matchers. Default: (\code{method}, \code{uri})
-See \link{request-matching} for details.
-\item \code{cassettes} (list) don't use
-\item \code{linked_context} (logical) linked context
-}
-}
-
-\subsection{Recordings}{
-\itemize{
-\item \code{serialize_with}: (character) only option is "yaml"
-\item \code{persist_with} (character) only option is "FileSystem"
-\item \code{uri_parser} the uri parser, default: \code{\link[crul:url_parse]{crul::url_parse()}}
-\item \code{preserve_exact_body_bytes} (logical) preserve exact body bytes for
-\item \code{turned_off} (logical) VCR is turned on by default. Default:
-\code{FALSE}
-\item \code{re_record_interval} (numeric) When given, the cassette will be
-re-recorded at the given interval, in seconds.
-\item \code{clean_outdated_http_interactions} (logical) Should outdated interactions
-be recorded back to file. Default: \code{FALSE}
 \item \code{write_disk_path} (character) path to write files to
 for any requests that write responses to disk. by default this parameter
 is \code{NULL}. For testing a package, you'll probably want this path to
@@ -57,27 +37,16 @@ files from requests that write to disk are in \code{tests/files}
 }
 }
 
-\subsection{Connectivity}{
+\subsection{Contexts}{
 \itemize{
+\item \code{turned_off} (logical) VCR is turned on by default. Default:
+\code{FALSE}
 \item \code{allow_unused_http_interactions} (logical) Default: \code{TRUE}
 \item \code{allow_http_connections_when_no_cassette} (logical) Determines how vcr
 treats HTTP requests that are made when no vcr cassette is in use. When
 \code{TRUE}, requests made when there is no vcr cassette in use will be allowed.
 When \code{FALSE} (default), an \link{UnhandledHTTPRequestError} error will be raised
 for any HTTP request made when there is no cassette in use
-}
-}
-
-\subsection{Logging}{
-\itemize{
-\item \code{log} (logical) should we log important vcr things? Default: \code{FALSE}
-\item \code{log_opts} (list) Additional logging options. Options include:
-\itemize{
-\item file: one of a file path to log to or "console"
-\item log_prefix: default: "Cassette". We insert the cassette name after
-that prefix, then the rest of the message
-\item More to come...
-}
 }
 }
 
@@ -88,14 +57,59 @@ google.com. These hosts are ignored and real HTTP requests allowed to go
 through
 \item \code{ignore_localhost} (logical) Default: \code{FALSE}
 \item \code{ignore_request} List of requests to ignore. NOT USED RIGHT NOW, sorry
-\item \code{filter_sensitive_data} (list) named list of values to replace. format
-is: \code{list(thing_to_replace_it_with = thing_to_replace)}. We replace all
-instances of \code{thing_to_replace} with \code{thing_to_replace_it_with}. Before
-recording (writing to a cassette) we do the replacement and then when
-reading from the cassette we do the reverse replacement to get back
-to the real data. Before record replacement happens in internal
-function \code{write_interactions()}, while before playback replacement
-happens in internal function \code{YAML$deserialize_path()}
+\item \code{filter_sensitive_data} named list of values to replace. Format is:\preformatted{list(thing_to_replace_it_with = thing_to_replace)
+}
+
+We replace all instances of \code{thing_to_replace} with
+\code{thing_to_replace_it_with}. Before recording (writing to a cassette) we do
+the replacement and then when reading from the cassette we do the reverse
+replacement to get back to the real data. Before record replacement happens
+in internal function \code{write_interactions()}, while before playback
+replacement happens in internal function \code{YAML$deserialize_path()}
+}
+}
+
+\subsection{Internals}{
+\itemize{
+\item \code{cassettes} (list) don't use
+\item \code{linked_context} (logical) linked context
+\item \code{uri_parser} the uri parser, default: \code{\link[crul:url_parse]{crul::url_parse()}}
+}
+}
+
+\subsection{Logging}{
+\itemize{
+\item \code{log} (logical) should we log important vcr things? Default: \code{FALSE}
+\item \code{log_opts} (list) Additional logging options:
+\itemize{
+\item \code{file} either \code{"console"} or a file path to log to
+\item \code{log_prefix} default: "Cassette". We insert the cassette name after
+that prefix, then the rest of the message.
+\item More to come...
+}
+}
+}
+
+}
+
+\subsection{Cassette Options}{
+
+These settings can be configured globally, using \code{vcr_configure()}, or
+locally, using either \code{use_cassette()} or \code{insert_cassette()}. Global
+settings are applied to \emph{all} cassettes but are overridden by settings
+defined locally for individuall cassettes.
+\itemize{
+\item \code{record} (character) One of 'all', 'none', 'new_episodes', or 'once'.
+See \link{recording}
+\item \code{match_requests_on} vector of matchers. Default: (\code{method}, \code{uri})
+See \link{request-matching} for details.
+\item \code{serialize_with}: (character) only option is "yaml"
+\item \code{persist_with} (character) only option is "FileSystem"
+\item \code{preserve_exact_body_bytes} (logical) preserve exact body bytes for
+\item \code{re_record_interval} (numeric) When given, the cassette will be
+re-recorded at the given interval, in seconds.
+\item \code{clean_outdated_http_interactions} (logical) Should outdated interactions
+be recorded back to file. Default: \code{FALSE}
 }
 }
 }
@@ -107,6 +121,7 @@ vcr_configuration()
 vcr_config_defaults()
 vcr_configure(dir = tempdir(), ignore_hosts = "google.com")
 vcr_configure(dir = tempdir(), ignore_localhost = TRUE)
+
 
 # logging
 vcr_configure(dir = tempdir(), log = TRUE,

--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -1,7 +1,16 @@
 tmpdir <- tempdir()
 library(vcr)
-vcr_configure(dir = tmpdir, write_disk_path = file.path(tmpdir, "files"))
 
+# define and restore consistent configuration options for tests
+vcr_test_configuration <- function(
+  dir = tmpdir,
+  write_disk_path = file.path(tmpdir, "files"),
+  ...) {
+  vcr_configure_reset()
+  vcr_configure(dir = dir, write_disk_path = write_disk_path, ...)
+}
+
+vcr_test_configuration()
 
 desc_text <- "Package: %s
 Title: Does A Thing

--- a/tests/testthat/test-configuration-inheritance.R
+++ b/tests/testthat/test-configuration-inheritance.R
@@ -1,0 +1,98 @@
+setup({
+  vcr_test_configuration()
+})
+
+# parameters shared by config and cassettes
+# (commented params are not exposed by Cassette$cassette_opts())
+params <- c(
+  "record",
+  "match_requests_on",
+  # "re_record_interval",
+  # "clean_outdated_http_interactions",
+  # "allow_unused_http_interactions",
+  "serialize_with",
+  "persist_with",
+  "preserve_exact_body_bytes"
+)
+
+test_that("default cassette options match default config", {
+  on.exit({
+    unlink(vcr_files())
+  })
+
+  config <- VCRConfig$new()
+  cas1 <- use_cassette("default-use", {})
+
+  expect_identical(
+    config$as_list()[params],
+    cas1$cassette_opts[params]
+  )
+
+  cas2 <- insert_cassette("default-insert")
+  eject_cassette()
+
+  expect_identical(
+    config$as_list()[params],
+    cas2$cassette_opts[params]
+  )
+})
+
+test_that("cassettes inherit configured options", {
+  on.exit({
+    unlink(vcr_files())
+    vcr_test_configuration()
+  })
+
+  vcr_configure(
+    record = "none",
+    match_requests_on = "body",
+    preserve_exact_body_bytes = TRUE
+  )
+
+  cas1 <- use_cassette("configured-use", {})
+
+  expect_match(cas1$record, "none")
+  expect_setequal(cas1$match_requests_on, "body")
+  expect_true(cas1$preserve_exact_body_bytes)
+
+  cas2 <- insert_cassette("configured-insert")
+  eject_cassette()
+
+  expect_match(cas2$record, "none")
+  expect_setequal(cas2$match_requests_on, "body")
+  expect_true(cas2$preserve_exact_body_bytes)
+})
+
+test_that("cassettes can override configured options", {
+  on.exit({
+    unlink(vcr_files())
+    vcr_test_configuration()
+  })
+
+  vcr_configure(
+    record = "none",
+    match_requests_on = "body",
+    preserve_exact_body_bytes = TRUE
+  )
+
+  cas1 <- use_cassette("overridden-use", {},
+    record = "new_episodes",
+    match_requests_on = "query",
+    preserve_exact_body_bytes = FALSE
+  )
+
+  expect_match(cas1$record, "new_episodes")
+  expect_setequal(cas1$match_requests_on, "query")
+  expect_false(cas1$preserve_exact_body_bytes)
+
+  cas2 <- insert_cassette("overridden-insert",
+    record = "new_episodes",
+    match_requests_on = "query",
+    preserve_exact_body_bytes = FALSE
+  )
+  eject_cassette()
+
+  expect_match(cas2$record, "new_episodes")
+  expect_setequal(cas2$match_requests_on, "query")
+  expect_false(cas2$preserve_exact_body_bytes)
+})


### PR DESCRIPTION
As discussed in #151. This changes the defaults for arguments in `use_cassette()`/`insert_cassette()` to `NULL` *if* they control parameters that are also configurable via `VCRConfig`. Before making this change I reformatted the code so there's only one argument per line to make the [diff](https://github.com/ropensci/vcr/pull/153/commits/3a24c0aa3fa50ab84ccd0f739ba70c346ef71084) more readable.

Other changes: 
* Adds test helper `vcr_test_configuration()` to reset the current configuration and restore settings that should be in place for all tests. This could be called within a `teardown()` block at the top of every test file that includes modifications to the configuration. Currently it's only used in the new inheritance tests.
* Adds tests to verify that cassettes inherit settings from `vcr_configuration()` 