### PR TITLE
Apply assertions to VCRConfig's initial arguments

### DIFF
--- a/R/configuration.R
+++ b/R/configuration.R
@@ -310,27 +310,27 @@ VCRConfig <- R6::R6Class(
       filter_sensitive_data = NULL,
       write_disk_path = NULL
     ) {
-      private$.dir <- dir
-      private$.record <- record
-      private$.match_requests_on <- match_requests_on
-      private$.allow_unused_http_interactions <- allow_unused_http_interactions
-      private$.serialize_with <- serialize_with
-      private$.persist_with <- persist_with
-      private$.ignore_hosts <- ignore_hosts
-      private$.ignore_localhost <- ignore_localhost
-      private$.ignore_request <- ignore_request
-      private$.uri_parser <- uri_parser
-      private$.preserve_exact_body_bytes <- preserve_exact_body_bytes
-      private$.turned_off <- turned_off
-      private$.re_record_interval <- re_record_interval
-      private$.clean_outdated_http_interactions <- clean_outdated_http_interactions
-      private$.allow_http_connections_when_no_cassette <- allow_http_connections_when_no_cassette
-      private$.cassettes <- cassettes
-      private$.linked_context <- linked_context
-      private$.log <- log
-      private$.log_opts <- log_opts
-      private$.filter_sensitive_data <- filter_sensitive_data
-      private$.write_disk_path <- write_disk_path
+      self$dir <- dir
+      self$record <- record
+      self$match_requests_on <- match_requests_on
+      self$allow_unused_http_interactions <- allow_unused_http_interactions
+      self$serialize_with <- serialize_with
+      self$persist_with <- persist_with
+      self$ignore_hosts <- ignore_hosts
+      self$ignore_localhost <- ignore_localhost
+      self$ignore_request <- ignore_request
+      self$uri_parser <- uri_parser
+      self$preserve_exact_body_bytes <- preserve_exact_body_bytes
+      self$turned_off <- turned_off
+      self$re_record_interval <- re_record_interval
+      self$clean_outdated_http_interactions <- clean_outdated_http_interactions
+      self$allow_http_connections_when_no_cassette <- allow_http_connections_when_no_cassette
+      self$cassettes <- cassettes
+      self$linked_context <- linked_context
+      self$log <- log
+      self$log_opts <- log_opts
+      self$filter_sensitive_data <- filter_sensitive_data
+      self$write_disk_path <- write_disk_path
     },
 
     # reset all settings to defaults


### PR DESCRIPTION
This is mostly an academic change with zero functional impact for users but I think it's the "correct" approach for adding assertions to R6 classes, so it might be useful as a reference if nothing else. 

In the current implementation assertions are only applied when updating the fields of an existing object, so it's possible to initialize an object with an invalid value:

``` r
config <- vcr:::VCRConfig$new(record = "once")
config$record <- 1
#> Error in check_record_mode(value): is.character(x) is not TRUE

vcr:::VCRConfig$new(record = 1)
#> <vcr configuration>
#>   Cassette Dir: .
#>   Record: 1
#>   URI Parser: crul::url_parse
#>   Match Requests on: method, uri
#>   Preserve Bytes?: FALSE
#>   Logging?: FALSE
#>   ignored hosts: 
#>   ignore localhost?: FALSE
#>   Write disk path:
```

With this new change, initial arguments are passed to the active binding rather than being assigned directly to their private field, so assertions are applied in both cases:

``` r
config <- vcr:::VCRConfig$new(record = "once")
config$record <- 1
#> Error in check_record_mode(value): is.character(x) is not TRUE

vcr:::VCRConfig$new(record = 1)
#> Error in check_record_mode(value): is.character(x) is not TRUE
```

<sup>Created on 2020-02-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

You have way more experience with R6 so I'm curious to see what you think and whether I'm missing something. 