### PR TITLE
Avoid huge error msg that causes infinite recursion

### DIFF
--- a/R/filter_sensitive_data.R
+++ b/R/filter_sensitive_data.R
@@ -11,10 +11,12 @@ sensitive_put_back <- function(x) {
   return(x)
 }
 sensitive_remove <- function(x) {
-  if (!is.null(vcr_c$filter_sensitive_data)) {
-    fsd <- vcr_c$filter_sensitive_data
+  fsd <- vcr_c$filter_sensitive_data
+  if (!is.null(fsd)) {
     for (i in seq_along(fsd)) {
-      x <- gsub(fsd[[i]], names(fsd)[i], x)
+      if (nchar(fsd[[i]]) > 0) {
+        x <- gsub(fsd[[i]], names(fsd)[i], x)
+      }
     }
   }
   return(x)


### PR DESCRIPTION
## Description

I was getting 'C stack usage 51050657 is too close to the limit' errors when testing `taxize` and determined it was caused by `sensitive_remove` improperly adding a lot of text that made a massive one line error message, which broke `stop`. I assume `stop` then called itself, and continued to do so infinitely.

This was caused by a series of `gsub` calls with `pattern = ""`, since `vcr_c$filter_sensitive_data` had `""` for each non-existent API key. I dont know enough about the package to know if that is normal.

## Related Issue

https://github.com/ropensci/taxize/pull/798

## Example

Here is an reprex of the issue, using the latest Github master branch:

```r
library(vcr)
vcr::vcr_configure(
  dir = "../fixtures",
  filter_sensitive_data = list(
    "<<rredlist_api_token>>" = Sys.getenv("IUCN_REDLIST_KEY"),
    "<<entrez_api_token>>" = Sys.getenv("ENTREZ_KEY"),
    "<<eol_api_token>>" = Sys.getenv("EOL_KEY"),
    "<<tropicos_api_token>>" = Sys.getenv("TROPICOS_KEY"),
    "<<natureserve_api_token>>" = Sys.getenv("NATURE_SERVE_KEY")
  )
)
x = UnhandledHTTPRequestError$new(Request$new(uri = 'api_key=123456789'),
                                  cassette = 'test')
nchar(x$request_description())
```
```
[1] 4703868
```
```r
substr(x$request_description(), 1, 1000)
```
```
[1] " <<natureserve_api_token>><<<natureserve_api_token>><<<natureserve_api_token>>t<<natureserve_api_token>>r<<natureserve_api_token>>o<<natureserve_api_token>>p<<natureserve_api_token>>i<<natureserve_api_token>>c<<natureserve_api_token>>o<<natureserve_api_token>>s<<natureserve_api_token>>_<<natureserve_api_token>>a<<natureserve_api_token>>p<<natureserve_api_token>>i<<natureserve_api_token>>_<<natureserve_api_token>>t<<natureserve_api_token>>o<<natureserve_api_token>>k<<natureserve_api_token>>e<<natureserve_api_token>>n<<natureserve_api_token>>><<natureserve_api_token>>><<natureserve_api_token>><<<natureserve_api_token>><<<natureserve_api_token>><<<natureserve_api_token>>t<<natureserve_api_token>>r<<natureserve_api_token>>o<<natureserve_api_token>>p<<natureserve_api_token>>i<<natureserve_api_token>>c<<natureserve_api_token>>o<<natureserve_api_token>>s<<natureserve_api_token>>_<<natureserve_api_token>>a<<natureserve_api_token>>p<<natureserve_api_token>>i<<natureserve_api_token>>_<<natureser"
```
```r
x$construct_message()
```
```
Error: C stack usage  9439163 is too close to the limit
```