### PR TITLE
Fix empty body match

### DIFF
--- a/R/request_handler.R
+++ b/R/request_handler.R
@@ -90,7 +90,7 @@ RequestHandler <- R6::R6Class(
       self$request_original <- request
       self$request <- {
         Request$new(request$method, request$url$url %||% request$url,
-          webmockr::pluck_body(request), request$headers,
+          webmockr::pluck_body(request) %||% "", request$headers,
           disk = !is.null(request$output$path))
       }
       self$cassette <- tryCatch(current_cassette(), error = function(e) e)

--- a/tests/testthat/test-ause_cassette_match_body_empty_body.R
+++ b/tests/testthat/test-ause_cassette_match_body_empty_body.R
@@ -1,0 +1,43 @@
+test_that("use_cassette: match on body w/ empty body", {
+  skip_on_cran()
+
+  library(crul)
+  mydir <- file.path(tempdir(), "asdfasdfsd")
+  invisible(vcr_configure(dir = mydir))
+  unlink(file.path(vcr_c$dir, "testing1.yml"))
+  cli <- HttpClient$new(url = "https://httpbin.org")
+
+  ### matchers: method, uri, body
+  # run it
+  aa <- use_cassette(name = "testing9", {
+    res <- cli$post("post")
+  }, match_requests_on = c("method", "uri", "body"))
+  # run it again
+  bb <- use_cassette(name = "testing9", {
+    res <- cli$post("post")
+  }, match_requests_on = c("method", "uri", "body"))
+    
+  # the request body in the crul request is empty
+  expect_null(res$request$body)
+
+  # the request body in the cassette is an empty string
+  cas <- yaml::yaml.load_file(file.path(mydir, "testing9.yml"))
+  expect_equal(cas$http_interactions[[1]]$request$body$string, "")
+
+  # NOTE: internally, the NULL in the request body gets turned into 
+  # an empty string, so we end up comparing an empty string to an empty
+  # string (in cases where no request bodies are sent or in a cassette
+  # that is)
+  
+  expect_is(aa, "Cassette")
+  expect_is(aa$name, "character")
+  expect_equal(aa$name, "testing9")
+  expect_equal(aa$match_requests_on, c("method", "uri", "body"))
+
+  # cleanup
+  unlink(mydir, recursive = TRUE)
+})
+
+# cleanup
+# reset configuration
+vcr_configure_reset()


### PR DESCRIPTION
Make request matching work for empty bodies when "body" is one of the matchers

## Description
in `RequestHandler` class, when on `$initialize()` we call `Request$new()` and set the body - but if the body is `NULL` that was cusing issues with body comparisons when there's an empty body (body not set by user) - Now we give empty string if `NULL` found for body

## Related Issue
 fix #157 

## Example

this works cleanly now

```r
library(vcr)
library(crul)
cli <- HttpClient$new(url = "https://httpbin.org")
vcr_configure(dir = "test-fixtures", match_requests_on = c("method", "uri", "body"))
bb <- use_cassette(name = "test-empty", {
  res2 <- cli$get("get")
})
```