### PR TITLE
start getting started

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -40,7 +40,7 @@ To install from CRAN
 install.packages("vcr")
 ```
 
-You can then set up your package to use VCR with:
+You can then set up your package to use `vcr` with:
 
 ```r
 vcr::use_vcr()
@@ -61,7 +61,7 @@ This will:
 ◉ Learn more about `vcr`: https://books.ropensci.org/http-testing
 ```
 
-If you need to use api keys for authentication, it's important to protect them. `vcr` saves responses from API's as YAML files, and this will include your api keys unless you indicate to `vcr` what they are and how to protect them. This is one of the uses  of the `helper-vrc` file that got made for us just now. By default it will look like this:
+If you need to use secrets (for example, api keys for authentication), it's important to protect them. `vcr` saves responses from API's as YAML files, and this will include your secrets unless you indicate to `vcr` what they are and how to protect them. This is one of the uses  of the `helper-vcr` file that got made for us just now. By default it will look like this:
 
 ```r
 library("vcr")
@@ -71,18 +71,18 @@ invisible(vcr::vcr_configure(
 vcr::check_cassette_names()
 ```
 
-Use the `filter_sensitive_data` argument in the `vcr_configure` function to show `vcr` how to keep you secret information secret. The best way to store secret information is to have it in a `.Renviron` file. Assuming that that is already in place, supply a named list to the `filter_sensitive_data` argument.
+Use the `filter_sensitive_data` argument in the `vcr_configure` function to show `vcr` how to keep you secret. The best way to store secret information is to have it in a `.Renviron` file. Assuming that that is already in place, supply a named list to the `filter_sensitive_data` argument.
 
 ```r
 library("vcr")
 invisible(vcr::vcr_configure(
-filter_sensitive_data = list("<<<my_api_key>>>" = Sys.getenv('APIKEY'),  # add this
+  filter_sensitive_data = list("<<<my_api_key>>>" = Sys.getenv('APIKEY'),  # add this
   dir = "../fixtures"
 ))
 vcr::check_cassette_names()
 ```
 
-The will get your secret information from the environment, and make sure that whenever `vcr` records a new cassette, it will replace the secret information with `"<<<my_api_key>>>"`. You can find out more about this in the [HTTP testing book](https://books.ropensci.org/http-testing/) chapter on security.
+The will get your secret information from the environment, and make sure that whenever `vcr` records a new cassette, it will replace the secret information with `<<<my_api_key>>>`. You can find out more about this in the [HTTP testing book](https://books.ropensci.org/http-testing/) chapter on security.
 
 ## Usage
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -32,6 +32,58 @@ Check out the [HTTP testing book](https://books.ropensci.org/http-testing) and t
 * [crul](https://github.com/ropensci/crul)
 * [httr](https://github.com/r-lib/httr)
 
+## Getting Started
+
+To install from CRAN
+
+```r
+install.packages("vcr")
+```
+
+You can then set up your package to use VCR with:
+
+```r
+vcr::use_vcr()
+```
+
+This will:
+
+```
+◉ Using package: vcr.example  
+◉ assuming fixtures at: tests/fixtures  
+✓ Adding vcr to Suggests field in DESCRIPTION  
+✓ Creating directory: ./tests/testthat  
+◉ Looking for testthat.R file or similar  
+✓ tests/testthat.R: added  
+✓ Adding vcr config to tests/testthat/helper-vcr.example.R  
+✓ Adding example test file tests/testthat/test-vcr_example.R  
+✓ .gitattributes: added  
+◉ Learn more about `vcr`: https://books.ropensci.org/http-testing
+```
+
+If you need to use api keys for authentication, it's important to protect them. `vcr` saves responses from API's as YAML files, and this will include your api keys unless you indicate to `vcr` what they are and how to protect them. This is one of the uses  of the `helper-vrc` file that got made for us just now. By default it will look like this:
+
+```r
+library("vcr")
+invisible(vcr::vcr_configure(
+  dir = "../fixtures"
+))
+vcr::check_cassette_names()
+```
+
+Use the `filter_sensitive_data` argument in the `vcr_configure` function to show `vcr` how to keep you secret information secret. The best way to store secret information is to have it in a `.Renviron` file. Assuming that that is already in place, supply a named list to the `filter_sensitive_data` argument.
+
+```r
+library("vcr")
+invisible(vcr::vcr_configure(
+filter_sensitive_data = list("<<<my_api_key>>>" = Sys.getenv('APIKEY'),  # add this
+  dir = "../fixtures"
+))
+vcr::check_cassette_names()
+```
+
+The will get your secret information from the environment, and make sure that whenever `vcr` records a new cassette, it will replace the secret information with `"<<<my_api_key>>>"`. You can find out more about this in the [HTTP testing book](https://books.ropensci.org/http-testing/) chapter on security.
+
 ## Usage
 
 ```{r echo=FALSE, results='hide'}


### PR DESCRIPTION
Include a gettings started section in the `README`

## Description

A Getting Started Section before the Usage Section, which describes default installation from CRAN, running `vcr::use_vcr`, and why and how to use `vcr_configure` in `helper-vcr`

## Related Issue

#170 