### PR TITLE
better vignette index in pkgdown?

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -57,3 +57,14 @@ reference:
       - response_summary
       - vcr_log_file
       - vcr_log_info
+
+articles:
+- title: All vignettes
+  desc: ~
+  contents:
+  - '`vcr`'
+  - '`cassette-manual-editing`'
+  - '`configuration`'
+  - '`request_matching`'
+  - '`debugging`'
+  - '`internals`'

--- a/vignettes/cassette-manual-editing.Rmd
+++ b/vignettes/cassette-manual-editing.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Why and how edit your vcr cassettes?"
+title: "Why and how to edit your vcr cassettes?"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{5. cassette manual editing}

--- a/vignettes/configuration.Rmd
+++ b/vignettes/configuration.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Tweak vcr default configuration"
+title: "Configure vcr"
 author: "Scott Chamberlain"
 date: "`r Sys.Date()`"
 output:

--- a/vignettes/configuration.Rmd
+++ b/vignettes/configuration.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "vcr configuration"
+title: "Tweak vcr default configuration"
 author: "Scott Chamberlain"
 date: "`r Sys.Date()`"
 output:

--- a/vignettes/request_matching.Rmd
+++ b/vignettes/request_matching.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Tweak vcr request matching"
+title: "Configure vcr request matching"
 author: "Scott Chamberlain"
 date: "`r Sys.Date()`"
 output:

--- a/vignettes/request_matching.Rmd
+++ b/vignettes/request_matching.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "request matching"
+title: "Tweak vcr request matching"
 author: "Scott Chamberlain"
 date: "`r Sys.Date()`"
 output:

--- a/vignettes/vcr.Rmd
+++ b/vignettes/vcr.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "vcr introduction"
+title: "Introduction to vcr"
 author: "Scott Chamberlain"
 date: "`r Sys.Date()`"
 output:


### PR DESCRIPTION
* All vignette titles now start with a capital letter and are a sentence
* Add an order from easy/most basic usage to advanced.