### PR TITLE
more vignettes, less duplication

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,4 +51,4 @@ Remotes: ropensci/webmockr
 X-schema.org-applicationCategory: Web
 X-schema.org-keywords: http, https, API, web-services, curl, mock, mocking, http-mocking, testing, testing-tools, tdd
 X-schema.org-isPartOf: https://ropensci.org
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.1.9000

--- a/R/lightswitch.R
+++ b/R/lightswitch.R
@@ -7,46 +7,7 @@
 #' inserted while vcr is turned off. If `TRUE` is passed, the cassette
 #' insertion will be ignored; otherwise an error will be raised.
 #' Default: `FALSE`
-#' @details
-#'
-#' - `turned_off()` - Turns vcr off for the duration of a block.
-#' - `turn_off()` - Turns vcr off, so that it no longer handles every
-#'  HTTP request
-#' - `turn_on()` - turns vcr on
-#' - `turned_on()` - Asks if vcr is turned on, gives a boolean
-#'
-#' To turn vcr off completely, for example, if you are using vcr in your
-#' package, but you want to run real HTTP requests in your tests, there are
-#' a few options:
-#'
-#' - Run `turn_off(ignore_cassettes = TRUE)` before running tests. You can
-#' do this on the command line e.g.,
-#' `Rscript -e 'vcr::turn_off(TRUE); devtools::test()'`, or within a running
-#' R session the same way.
-#' - Set an environment variable `VCR_TURN_OFF=TRUE`.
-#' You can do this on the command line by setting the env var at the beginning
-#' of the line like: `VCR_TURN_OFF=TRUE Rscript -e 'devtools::test()'`. Same
-#' can be done within an interactive R session. You can also use this approach
-#' to turn on or off vcr in CI builds like on Travis or Appveyor by setting
-#' this env var in your Travis/Appveyor configuration file or in the settings
-#' windows in the respective web apps
-#' 
-#' The full set of environment variables `vcr` uses, all of which accept only
-#' `TRUE` or `FALSE`:
-#' 
-#' - `VCR_TURN_OFF`: turn off vcr altogether; set to `TRUE` to skip any vcr
-#' usage; default: `FALSE`
-#' - `VCR_TURNED_OFF`: set the `turned_off` internal package setting; this
-#' does not turn off vcr completely as does `VCR_TURN_OFF` does, but rather
-#' is looked at together with `VCR_IGNORE_CASSETTES`
-#' - `VCR_IGNORE_CASSETTES`: set the `ignore_cassettes` internal package
-#' setting; this is looked at together with `VCR_TURNED_OFF`
-#' 
-#' See the HTTP testing book for more details 
-#' https://books.ropensci.org/http-testing/lightswitch.html
-#' 
-#' See `?Startup` if you're not sure how to set environment variables
-#'
+#' @includeRmd man/rmdhunks/lightswitch.Rmd
 #' @examples \dontrun{
 #' vcr_configure(dir = tempdir())
 #'

--- a/R/recording.R
+++ b/R/recording.R
@@ -1,51 +1,6 @@
 #' vcr recording options
 #'
-#' @section once:
-#' The `once` record mode will:
-#'
-#' - Replay previously recorded interactions.
-#' - Record new interactions if there is no cassette file.
-#' - Cause an error to be raised for new requests if there is a cassette file.
-#'
-#'
-#' It is similar to the `new_episodes` record mode, but will prevent new,
-#' unexpected requests from being made (i.e. because the request URI changed
-#' or whatever).
-#'
-#' `once` is the default record mode, used when you do not set one.
-#'
-#' @section none:
-#' The `none` record mode will:
-#'
-#' - Replay previously recorded interactions.
-#' - Cause an error to be raised for any new requests.
-#'
-#'
-#' This is useful when your code makes potentially dangerous
-#' HTTP requests.  The `none` record mode guarantees that no
-#' new HTTP requests will be made.
-#'
-#' @section new_episodes:
-#' The `new_episodes` record mode will:
-#'
-#' - Record new interactions.
-#' - Replay previously recorded interactions.
-#'
-#'
-#' It is similar to the `once` record mode, but will **always** record new
-#' interactions, even if you have an existing recorded one that is similar
-#' (but not identical, based on the `match_request_on` option).
-#'
-#' @section all:
-#' The `all` record mode will:
-#'
-#' - Record new interactions.
-#' - Never replay previously recorded interactions.
-#'
-#'
-#' This can be temporarily used to force \pkg{vcr} to re-record
-#' a cassette (i.e. to ensure the responses are not out of date)
-#' or can be used when you simply want to log all HTTP requests.
+#' @includeRmd man/rmdhunks/record-modes.Rmd
 #'
 #' @name recording
 NULL

--- a/R/request_matching.R
+++ b/R/request_matching.R
@@ -3,39 +3,7 @@
 #' There are a number of options, some of which are on by default, some of
 #' which can be used together, and some alone.
 #'
-#' @section matching on method:
-#' Use the **method** request matcher to match requests on the HTTP method
-#' (i.e. GET, POST, PUT, DELETE, etc). You will generally want to use
-#' this matcher. The **method** matcher is used (along with the **uri** matcher)
-#' by default if you do not specify how requests should match.
-#'
-#' @section matching on uri:
-#' Use the **uri** request matcher to match requests on the request URI. The
-#' **uri** matcher is used (along with the **method** matcher) by default
-#' if you do not specify how requests should match.
-#'
-#' @section matching on host:
-#' Use the **host** request matcher to match requests on the request host.
-#' You can use this (alone, or in combination with **path**) as an
-#' alternative to **uri** so that non-deterministic portions of the URI
-#' are not considered as part of the request matching.
-#'
-#' @section matching on path:
-#' Use the **path** request matcher to match requests on the path portion
-#' of the request URI. You can use this (alone, or in combination with **host**)
-#' as an alternative to **uri** so that non-deterministic portions of the URI
-#'
-#' @section matching on query string:
-#' Use the **query** request matcher to match requests on the query string
-#' portion of the request URI. You can use this (alone, or in combination with
-#' others) as an alternative to **uri** so that non-deterministic portions of
-#' the URI are not considered as part of the request matching.
-#'
-#' @section matching on body:
-#' Use the **body** request matcher to match requests on the request body.
-#'
-#' @section matching on headers:
-#' Use the **headers** request matcher to match requests on the request headers.
+#' @includeRmd man/rmdhunks/request-matching-vignette.Rmd
 #'
 #' @name request-matching
 NULL

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -67,4 +67,7 @@ articles:
   - '`configuration`'
   - '`request_matching`'
   - '`debugging`'
+  - '`write-to-disk`'
+  - '`record-modes`'
+  - '`lightswitch`'
   - '`internals`'

--- a/man/lightswitch.Rd
+++ b/man/lightswitch.Rd
@@ -28,47 +28,133 @@ Default: \code{FALSE}}
 Turn vcr on and off, check on/off status, and turn off for a given http call
 }
 \details{
+Sometimes you may need to turn off \code{vcr}, either for individual function
+calls, individual test blocks, whole test files, or for the entire
+package. The following attempts to break down all the options.
+
+\code{vcr} has the following four exported functions:
 \itemize{
-\item \code{turned_off()} - Turns vcr off for the duration of a block.
-\item \code{turn_off()} - Turns vcr off, so that it no longer handles every
-HTTP request
-\item \code{turn_on()} - turns vcr on
-\item \code{turned_on()} - Asks if vcr is turned on, gives a boolean
+\item \code{turned_off()} - Turns vcr off for the duration of a code block
+\item \code{turn_off()} - Turns vcr off completely, so that it no longer
+handles every HTTP request
+\item \code{turn_on()} - turns vcr on; the opposite of \code{turn_off()}
+\item \code{turned_on()} - Asks if vcr is turned on, returns a boolean
 }
 
-To turn vcr off completely, for example, if you are using vcr in your
-package, but you want to run real HTTP requests in your tests, there are
-a few options:
+Instead of using the above four functions, you could use environment
+variables to achieve the same thing. This way you could enable/disable
+\code{vcr} in non-interactive environments such as continuous integration,
+Docker containers, or running R non-interactively from the command line.
+The full set of environment variables \code{vcr} uses, all of which accept
+only \code{TRUE} or \code{FALSE}:
 \itemize{
-\item Run \code{turn_off(ignore_cassettes = TRUE)} before running tests. You can
-do this on the command line e.g.,
-\verb{Rscript -e 'vcr::turn_off(TRUE); devtools::test()'}, or within a running
-R session the same way.
-\item Set an environment variable \code{VCR_TURN_OFF=TRUE}.
-You can do this on the command line by setting the env var at the beginning
-of the line like: \verb{VCR_TURN_OFF=TRUE Rscript -e 'devtools::test()'}. Same
-can be done within an interactive R session. You can also use this approach
-to turn on or off vcr in CI builds like on Travis or Appveyor by setting
-this env var in your Travis/Appveyor configuration file or in the settings
-windows in the respective web apps
-}
-
-The full set of environment variables \code{vcr} uses, all of which accept only
-\code{TRUE} or \code{FALSE}:
-\itemize{
-\item \code{VCR_TURN_OFF}: turn off vcr altogether; set to \code{TRUE} to skip any vcr
-usage; default: \code{FALSE}
-\item \code{VCR_TURNED_OFF}: set the \code{turned_off} internal package setting; this
-does not turn off vcr completely as does \code{VCR_TURN_OFF} does, but rather
-is looked at together with \code{VCR_IGNORE_CASSETTES}
+\item \code{VCR_TURN_OFF}: turn off vcr altogether; set to \code{TRUE} to skip any
+vcr usage; default: \code{FALSE}
+\item \code{VCR_TURNED_OFF}: set the \code{turned_off} internal package setting;
+this does not turn off vcr completely as does \code{VCR_TURN_OFF} does,
+but rather is looked at together with \code{VCR_IGNORE_CASSETTES}
 \item \code{VCR_IGNORE_CASSETTES}: set the \code{ignore_cassettes} internal package
 setting; this is looked at together with \code{VCR_TURNED_OFF}
 }
+\subsection{turned_off}{
 
-See the HTTP testing book for more details
-https://books.ropensci.org/http-testing/lightswitch.html
+\code{turned_off()} lets you temporarily make a real HTTP request without
+completely turning \code{vcr} off, unloading it, etc.
 
-See \code{?Startup} if you're not sure how to set environment variables
+What happens internally is we turn off \code{vcr}, run your code block, then
+on exit turn \code{vcr} back on - such that \code{vcr} is only turned off for the
+duration of your code block. Even if your code block errors, \code{vcr} will
+be turned back on due to use of \code{on.exit(turn_on())}\if{html}{\out{<div class="r">}}\preformatted{library(vcr)
+library(crul)
+turned_off(\{
+  con <- HttpClient$new(url = "https://httpbin.org/get")
+  con$get()
+\})
+}\if{html}{\out{</div>}}\if{html}{\out{<div class="r">}}\preformatted{#> <crul response>
+#>   url: https://httpbin.org/get
+#>   request_headers:
+#>     User-Agent: libcurl/7.54.0 r-curl/4.3 crul/0.9.0
+#>     Accept-Encoding: gzip, deflate
+#>     Accept: application/json, text/xml, application/xml, */*
+#>   response_headers:
+#>     status: HTTP/1.1 200 OK
+#>     date: Fri, 14 Feb 2020 19:44:46 GMT
+#>     content-type: application/json
+#>     content-length: 365
+#>     connection: keep-alive
+#>     server: gunicorn/19.9.0
+#>     access-control-allow-origin: *
+#>     access-control-allow-credentials: true
+#>   status: 200
+}\if{html}{\out{</div>}}
+}
+
+\subsection{turn_off/turn_on}{
+
+\code{turn_off()} is different from \code{turned_off()} in that \code{turn_off()} is
+not aimed at a single call block, but rather it turns \code{vcr} off for the
+entire package. \code{turn_off()} does check first before turning \code{vcr} off
+that there is not currently a cassette in use. \code{turn_off()} is meant to
+make R ignore \code{vcr::insert_cassette()} and \code{vcr::use_cassette()} blocks
+in your test suite - letting the code in the block run as if they were
+not wrapped in \code{vcr} code - so that all you have to do to run your tests
+with cached requests/responses AND with real HTTP requests is toggle a
+single R function or environment variable.\if{html}{\out{<div class="r">}}\preformatted{library(vcr)
+vcr_configure(dir = tempdir())
+# real HTTP request works - vcr is not engaged here
+crul::HttpClient$new(url = "https://eu.httpbin.org/get")$get()
+# wrap HTTP request in use_cassette() - vcr is engaged here
+use_cassette("foo_bar", \{
+  crul::HttpClient$new(url = "https://eu.httpbin.org/get")$get()
+\})
+# turn off & ignore cassettes - use_cassette is ignored, real HTTP request made
+turn_off(ignore_cassettes = TRUE)
+use_cassette("foo_bar", \{
+  crul::HttpClient$new(url = "https://eu.httpbin.org/get")$get()
+\})
+# if you turn off and don't ignore cassettes, error thrown
+turn_off(ignore_cassettes = FALSE)
+use_cassette("foo_bar", \{
+  res2=crul::HttpClient$new(url = "https://eu.httpbin.org/get")$get()
+\})
+# vcr back on - now use_cassette behaves as before
+turn_on()
+use_cassette("foo_bar3", \{
+  res2=crul::HttpClient$new(url = "https://eu.httpbin.org/get")$get()
+\})
+}\if{html}{\out{</div>}}
+}
+
+\subsection{turned_on}{
+
+\code{turned_on()} does what it says on the tin - it tells you if \code{vcr} is
+turned on or not.\if{html}{\out{<div class="r">}}\preformatted{library(vcr)
+turn_on()
+turned_on()
+}\if{html}{\out{</div>}}\preformatted{## [1] TRUE
+}\if{html}{\out{<div class="r">}}\preformatted{turn_off()
+}\if{html}{\out{</div>}}\preformatted{## vcr turned off; see ?turn_on to turn vcr back on
+}\if{html}{\out{<div class="r">}}\preformatted{turned_on()
+}\if{html}{\out{</div>}}\preformatted{## [1] FALSE
+}
+}
+
+\subsection{Environment variables}{
+
+The \code{VCR_TURN_OFF} environment variable can be used within R or on the
+command line to turn off \code{vcr}. For example, you can run tests for a
+package that uses \code{vcr}, but ignore any \code{use_cassette}/\code{insert_cassette}
+usage, by running this on the command line in the root of your package:\preformatted{VCR_TURN_OFF=true Rscript -e "devtools::test()"
+}
+
+Or, similarly within R:\if{html}{\out{<div class="r">}}\preformatted{Sys.setenv(VCR_TURN_OFF = TRUE)
+devtools::test()
+}\if{html}{\out{</div>}}
+
+The \code{VCR_TURNED_OFF} and \code{VCR_IGNORE_CASSETTES} environment variables
+can be used in combination to achieve the same thing as \code{VCR_TURN_OFF}:\preformatted{VCR_TURNED_OFF=true VCR_IGNORE_CASSETTES=true Rscript -e "devtools::test()"
+}
+}
 }
 \examples{
 \dontrun{

--- a/man/recording.Rd
+++ b/man/recording.Rd
@@ -6,23 +6,29 @@
 \description{
 vcr recording options
 }
-\section{once}{
+\details{
+Record modes dictate under what circumstances http requests/responses
+are recorded to cassettes (disk). Set the recording mode with the
+parameter \code{record} in the \code{use_cassette()} and \code{insert_cassette()}
+functions.
+\subsection{once}{
 
 The \code{once} record mode will:
 \itemize{
 \item Replay previously recorded interactions.
 \item Record new interactions if there is no cassette file.
-\item Cause an error to be raised for new requests if there is a cassette file.
+\item Cause an error to be raised for new requests if there is a cassette
+file.
 }
 
 It is similar to the \code{new_episodes} record mode, but will prevent new,
-unexpected requests from being made (i.e. because the request URI changed
-or whatever).
+unexpected requests from being made (i.e. because the request URI
+changed or whatever).
 
 \code{once} is the default record mode, used when you do not set one.
 }
 
-\section{none}{
+\subsection{none}{
 
 The \code{none} record mode will:
 \itemize{
@@ -30,12 +36,12 @@ The \code{none} record mode will:
 \item Cause an error to be raised for any new requests.
 }
 
-This is useful when your code makes potentially dangerous
-HTTP requests.  The \code{none} record mode guarantees that no
-new HTTP requests will be made.
+This is useful when your code makes potentially dangerous HTTP requests.
+The \code{none} record mode guarantees that no new HTTP requests will be
+made.
 }
 
-\section{new_episodes}{
+\subsection{new_episodes}{
 
 The \code{new_episodes} record mode will:
 \itemize{
@@ -48,7 +54,7 @@ interactions, even if you have an existing recorded one that is similar
 (but not identical, based on the \code{match_request_on} option).
 }
 
-\section{all}{
+\subsection{all}{
 
 The \code{all} record mode will:
 \itemize{
@@ -56,8 +62,8 @@ The \code{all} record mode will:
 \item Never replay previously recorded interactions.
 }
 
-This can be temporarily used to force \pkg{vcr} to re-record
-a cassette (i.e. to ensure the responses are not out of date)
-or can be used when you simply want to log all HTTP requests.
+This can be temporarily used to force vcr to re-record a cassette
+(i.e. to ensure the responses are not out of date) or can be used when
+you simply want to log all HTTP requests.
 }
-
+}

--- a/man/request-matching.Rd
+++ b/man/request-matching.Rd
@@ -7,51 +7,72 @@
 There are a number of options, some of which are on by default, some of
 which can be used together, and some alone.
 }
-\section{matching on method}{
+\details{
+To match previously recorded requests, \code{vcr} has to try to match new
+HTTP requests to a previously recorded one. By default, we match on HTTP
+method (e.g., \code{GET}) and URI (e.g., \verb{http://foo.com}), following Ruby’s
+VCR gem.
 
-Use the \strong{method} request matcher to match requests on the HTTP method
-(i.e. GET, POST, PUT, DELETE, etc). You will generally want to use
-this matcher. The \strong{method} matcher is used (along with the \strong{uri} matcher)
-by default if you do not specify how requests should match.
+You can customize how we match requests with one or more of the
+following options, some of which are on by default, some of which can be
+used together, and some alone.
+\itemize{
+\item \code{method}: Use the \strong{method} request matcher to match requests on
+the HTTP method (i.e. GET, POST, PUT, DELETE, etc). You will
+generally want to use this matcher. The \strong{method} matcher is used
+(along with the \strong{uri} matcher) by default if you do not specify
+how requests should match.
+\item \code{uri}: Use the \strong{uri} request matcher to match requests on the
+request URI. The \strong{uri} matcher is used (along with the \strong{method}
+matcher) by default if you do not specify how requests should match.
+\item \code{host}: Use the \strong{host} request matcher to match requests on the
+request host. You can use this (alone, or in combination with
+\strong{path}) as an alternative to \strong{uri} so that non-deterministic
+portions of the URI are not considered as part of the request
+matching.
+\item \code{path}: Use the \strong{path} request matcher to match requests on the
+path portion of the request URI. You can use this (alone, or in
+combination with \strong{host}) as an alternative to \strong{uri} so that
+non-deterministic portions of the URI
+\item \code{query}: Use the \strong{query} request matcher to match requests on the
+query string portion of the request URI. You can use this (alone, or
+in combination with others) as an alternative to \strong{uri} so that
+non-deterministic portions of the URI are not considered as part of
+the request matching.
+\item \code{body}: Use the \strong{body} request matcher to match requests on the
+request body.
+\item \code{headers}: Use the \strong{headers} request matcher to match requests on
+the request headers.
 }
 
-\section{matching on uri}{
-
-Use the \strong{uri} request matcher to match requests on the request URI. The
-\strong{uri} matcher is used (along with the \strong{method} matcher) by default
-if you do not specify how requests should match.
+You can set your own options by tweaking the \code{match_requests_on}
+parameter in \code{use_cassette()}:\if{html}{\out{<div class="r">}}\preformatted{library(vcr)
+}\if{html}{\out{</div>}}\if{html}{\out{<div class="r">}}\preformatted{use_cassette(name = "foo_bar", \{
+    cli$post("post", body = list(a = 5))
+  \}, 
+  match_requests_on = c('method', 'headers', 'body')
+)
+}\if{html}{\out{</div>}}
+\subsection{Matching}{
+\subsection{headers}{\if{html}{\out{<div class="r">}}\preformatted{library(crul)
+library(vcr)
+cli <- crul::HttpClient$new("https://httpbin.org/get", 
+  headers = list(foo = "bar"))
+use_cassette(name = "nothing_new", \{
+    one <- cli$get()
+  \}, 
+  match_requests_on = 'headers'
+)
+cli$headers$foo <- "stuff"
+use_cassette(name = "nothing_new", \{
+    two <- cli$get()
+  \}, 
+  match_requests_on = 'headers'
+)
+one$request_headers
+two$request_headers
+}\if{html}{\out{</div>}}
 }
 
-\section{matching on host}{
-
-Use the \strong{host} request matcher to match requests on the request host.
-You can use this (alone, or in combination with \strong{path}) as an
-alternative to \strong{uri} so that non-deterministic portions of the URI
-are not considered as part of the request matching.
 }
-
-\section{matching on path}{
-
-Use the \strong{path} request matcher to match requests on the path portion
-of the request URI. You can use this (alone, or in combination with \strong{host})
-as an alternative to \strong{uri} so that non-deterministic portions of the URI
 }
-
-\section{matching on query string}{
-
-Use the \strong{query} request matcher to match requests on the query string
-portion of the request URI. You can use this (alone, or in combination with
-others) as an alternative to \strong{uri} so that non-deterministic portions of
-the URI are not considered as part of the request matching.
-}
-
-\section{matching on body}{
-
-Use the \strong{body} request matcher to match requests on the request body.
-}
-
-\section{matching on headers}{
-
-Use the \strong{headers} request matcher to match requests on the request headers.
-}
-

--- a/man/rmdhunks/lightswitch.Rmd
+++ b/man/rmdhunks/lightswitch.Rmd
@@ -1,0 +1,142 @@
+
+Sometimes you may need to turn off `vcr`, either for individual
+function calls, individual test blocks, whole test files, or
+for the entire package. The following attempts to break down
+all the options.
+
+`vcr` has the following four exported functions:
+
+- `turned_off()` - Turns vcr off for the duration of a code block
+- `turn_off()` - Turns vcr off completely, so that it no longer handles every
+HTTP request
+- `turn_on()` - turns vcr on; the opposite of `turn_off()`
+- `turned_on()` - Asks if vcr is turned on, returns a boolean
+
+Instead of using the above four functions, you could use environment
+variables to achieve the same thing. This way you could enable/disable
+`vcr` in non-interactive environments such as continuous integration,
+Docker containers, or running R non-interactively from the command line.
+The full set of environment variables `vcr` uses, all of which accept
+only `TRUE` or `FALSE`:
+
+- `VCR_TURN_OFF`: turn off vcr altogether; set to `TRUE` to skip any vcr
+usage; default: `FALSE`
+- `VCR_TURNED_OFF`: set the `turned_off` internal package setting; this
+does not turn off vcr completely as does `VCR_TURN_OFF` does, but rather
+is looked at together with `VCR_IGNORE_CASSETTES`
+- `VCR_IGNORE_CASSETTES`: set the `ignore_cassettes` internal package
+setting; this is looked at together with `VCR_TURNED_OFF`
+
+## turned_off {#turned-off}
+
+`turned_off()` lets you temporarily make a real HTTP request without completely turning
+`vcr` off, unloading it, etc.
+
+What happens internally is we turn off `vcr`, run your code block, then on exit
+turn `vcr` back on - such that `vcr` is only turned off for the duration of your
+code block. Even if your code block errors, `vcr` will be turned back on
+due to use of `on.exit(turn_on())`
+
+```r
+library(vcr)
+library(crul)
+turned_off({
+  con <- HttpClient$new(url = "https://httpbin.org/get")
+  con$get()
+})
+```
+
+```r
+#> <crul response>
+#>   url: https://httpbin.org/get
+#>   request_headers:
+#>     User-Agent: libcurl/7.54.0 r-curl/4.3 crul/0.9.0
+#>     Accept-Encoding: gzip, deflate
+#>     Accept: application/json, text/xml, application/xml, */*
+#>   response_headers:
+#>     status: HTTP/1.1 200 OK
+#>     date: Fri, 14 Feb 2020 19:44:46 GMT
+#>     content-type: application/json
+#>     content-length: 365
+#>     connection: keep-alive
+#>     server: gunicorn/19.9.0
+#>     access-control-allow-origin: *
+#>     access-control-allow-credentials: true
+#>   status: 200
+```
+
+## turn_off/turn_on {#turn-off-on}
+
+`turn_off()` is different from `turned_off()` in that `turn_off()` is not aimed
+at a single call block, but rather it turns `vcr` off for the entire package.
+`turn_off()` does check first before turning `vcr` off that there is not currently
+a cassette in use. `turn_off()` is meant to make R ignore `vcr::insert_cassette()`
+and `vcr::use_cassette()` blocks in your test suite - letting the code in the block
+run as if they were not wrapped in `vcr` code - so that all you have to do to run
+your tests with cached requests/responses AND with real HTTP requests is toggle
+a single R function or environment variable.
+
+```r
+library(vcr)
+vcr_configure(dir = tempdir())
+# real HTTP request works - vcr is not engaged here
+crul::HttpClient$new(url = "https://eu.httpbin.org/get")$get()
+# wrap HTTP request in use_cassette() - vcr is engaged here
+use_cassette("foo_bar", {
+  crul::HttpClient$new(url = "https://eu.httpbin.org/get")$get()
+})
+# turn off & ignore cassettes - use_cassette is ignored, real HTTP request made
+turn_off(ignore_cassettes = TRUE)
+use_cassette("foo_bar", {
+  crul::HttpClient$new(url = "https://eu.httpbin.org/get")$get()
+})
+# if you turn off and don't ignore cassettes, error thrown
+turn_off(ignore_cassettes = FALSE)
+use_cassette("foo_bar", {
+  res2=crul::HttpClient$new(url = "https://eu.httpbin.org/get")$get()
+})
+# vcr back on - now use_cassette behaves as before
+turn_on()
+use_cassette("foo_bar3", {
+  res2=crul::HttpClient$new(url = "https://eu.httpbin.org/get")$get()
+})
+```
+
+## turned_on {#turned-on}
+
+`turned_on()` does what it says on the tin - it tells you if `vcr` is turned on
+or not. 
+
+```{r}
+library(vcr)
+turn_on()
+turned_on()
+turn_off()
+turned_on()
+```
+
+## Environment variables {#lightswitch-env-vars}
+
+The `VCR_TURN_OFF` environment variable can be used within R or on the command line
+to turn off `vcr`. For example, you can run tests for a package that uses `vcr`, but
+ignore any `use_cassette`/`insert_cassette` usage, by running this on the command
+line in the root of your package:
+
+```
+VCR_TURN_OFF=true Rscript -e "devtools::test()"
+```
+
+Or, similarly within R:
+
+```r
+Sys.setenv(VCR_TURN_OFF = TRUE)
+devtools::test()
+```
+
+The `VCR_TURNED_OFF` and `VCR_IGNORE_CASSETTES` environment variables can be used
+in combination to achieve the same thing as `VCR_TURN_OFF`:
+
+```
+VCR_TURNED_OFF=true VCR_IGNORE_CASSETTES=true Rscript -e "devtools::test()"
+```
+

--- a/man/rmdhunks/record-modes.Rmd
+++ b/man/rmdhunks/record-modes.Rmd
@@ -1,0 +1,54 @@
+Record modes dictate under what circumstances http requests/responses are
+recorded to cassettes (disk). Set the recording mode with the parameter 
+`record` in the `use_cassette()` and `insert_cassette()` functions.
+
+## once
+
+The `once` record mode will:
+
+- Replay previously recorded interactions.
+- Record new interactions if there is no cassette file.
+- Cause an error to be raised for new requests if there is a cassette file.
+
+
+It is similar to the `new_episodes` record mode, but will prevent new,
+unexpected requests from being made (i.e. because the request URI changed
+or whatever).
+
+`once` is the default record mode, used when you do not set one.
+
+## none
+
+The `none` record mode will:
+
+- Replay previously recorded interactions.
+- Cause an error to be raised for any new requests.
+
+
+This is useful when your code makes potentially dangerous
+HTTP requests.  The `none` record mode guarantees that no
+new HTTP requests will be made.
+
+## new_episodes
+
+The `new_episodes` record mode will:
+
+- Record new interactions.
+- Replay previously recorded interactions.
+
+
+It is similar to the `once` record mode, but will **always** record new
+interactions, even if you have an existing recorded one that is similar
+(but not identical, based on the `match_request_on` option).
+
+## all
+
+The `all` record mode will:
+
+- Record new interactions.
+- Never replay previously recorded interactions.
+
+
+This can be temporarily used to force vcr to re-record
+a cassette (i.e. to ensure the responses are not out of date)
+or can be used when you simply want to log all HTTP requests.

--- a/man/rmdhunks/write-to-disk.Rmd
+++ b/man/rmdhunks/write-to-disk.Rmd
@@ -1,0 +1,72 @@
+If you have http requests for which you write the response to disk, then
+use `vcr_configure()` to set the `write_disk_path` option. See more about 
+the write_disk_path configuration option in `vignette("configuration", package = "vcr")`.
+
+Here, we create a temporary directory, then set the fixtures
+
+```{r}
+tmpdir <- tempdir()
+vcr_configure(
+  dir = file.path(tmpdir, "fixtures"),
+  write_disk_path = file.path(tmpdir, "files")
+)
+```
+
+Then pass a file path (that doesn't exist yet) to crul's `disk` parameter.
+`vcr` will take care of handling writing the response to that file in
+addition to the cassette.
+
+```{r}
+library(crul)
+## make a temp file
+f <- tempfile(fileext = ".json")
+## make a request
+cas <- use_cassette("test_write_to_disk", {
+  out <- HttpClient$new("https://httpbin.org/get")$get(disk = f)
+})
+file.exists(out$content)
+out$parse()
+```
+
+This also works with `httr`. The only difference is that you write to disk
+with a function `httr::write_disk(path)` rather than a parameter.
+
+Note that when you write to disk when using `vcr`, the cassette is slightly
+changed. Instead of holding the http response body itself, the cassette
+has the file path with the response body.
+
+```yaml
+http_interactions:
+- request:
+    method: get
+    uri: https://httpbin.org/get
+  response:
+    headers:
+      status: HTTP/1.1 200 OK
+      access-control-allow-credentials: 'true'
+    body:
+      encoding: UTF-8
+      file: yes
+      string: /private/var/folders/fc/n7g_vrvn0sx_st0p8lxb3ts40000gn/T/Rtmp5W4olr/files/file177e2e5d97ec.json
+```
+
+And the file has the response body that otherwise would have been in the `string`
+yaml field above:
+
+```json
+{
+  "args": {}, 
+  "headers": {
+    "Accept": "application/json, text/xml, application/xml, */*", 
+    "Accept-Encoding": "gzip, deflate", 
+    "Host": "httpbin.org", 
+    "User-Agent": "libcurl/7.54.0 r-curl/4.3 crul/0.9.0"
+  }, 
+  "origin": "24.21.229.59, 24.21.229.59", 
+  "url": "https://httpbin.org/get"
+}
+```
+
+```{r echo=FALSE}
+invisible(vcr_configure_reset())
+```

--- a/vignettes/lightswitch.Rmd
+++ b/vignettes/lightswitch.Rmd
@@ -1,0 +1,26 @@
+---
+title: "Turning vcr on and off"
+date: "`r Sys.Date()`"
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    theme: readable
+vignette: >
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+```{r setup}
+library(vcr)
+```
+
+```{r child='../man/rmdhunks/lightswitch.Rmd', eval=TRUE} 
+```

--- a/vignettes/lightswitch.Rmd
+++ b/vignettes/lightswitch.Rmd
@@ -25,3 +25,8 @@ library(vcr)
 
 ```{r child='../man/rmdhunks/lightswitch.Rmd', eval=TRUE} 
 ```
+
+```{r, echo=FALSE}
+
+vcr::turn_on()
+```

--- a/vignettes/lightswitch.Rmd
+++ b/vignettes/lightswitch.Rmd
@@ -7,6 +7,7 @@ output:
     toc_float: true
     theme: readable
 vignette: >
+  %\VignetteIndexEntry{Turning vcr on and off}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/record-modes.Rmd
+++ b/vignettes/record-modes.Rmd
@@ -1,0 +1,33 @@
+---
+title: "Record modes"
+author: "Scott Chamberlain"
+date: "`r Sys.Date()`"
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    theme: readable
+vignette: >
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r echo=FALSE}
+knitr::opts_chunk$set(
+    comment = "#>",
+    collapse = TRUE,
+    warning = FALSE,
+    message = FALSE
+)
+```
+
+Request matching
+================
+
+```{r child='../man/rmdhunks/record-modes.Rmd', eval=TRUE} 
+```
+
+## More documentation
+
+Check out the [http testing book](https://books.ropensci.org/http-testing/) for a lot more documentation on `vcr`, `webmockr`, and `crul`
+

--- a/vignettes/record-modes.Rmd
+++ b/vignettes/record-modes.Rmd
@@ -8,6 +8,7 @@ output:
     toc_float: true
     theme: readable
 vignette: >
+  %\VignetteIndexEntry{vcr record modes}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/write-to-disk.Rmd
+++ b/vignettes/write-to-disk.Rmd
@@ -27,7 +27,6 @@ Request matching
 
 ```{r setup}
 library("vcr")
-vcr::turn_on()
 ```
 
 ```{r child='../man/rmdhunks/write-to-disk.Rmd', eval=TRUE} 

--- a/vignettes/write-to-disk.Rmd
+++ b/vignettes/write-to-disk.Rmd
@@ -27,6 +27,7 @@ Request matching
 
 ```{r setup}
 library("vcr")
+vcr::turn_on()
 ```
 
 ```{r child='../man/rmdhunks/write-to-disk.Rmd', eval=TRUE} 

--- a/vignettes/write-to-disk.Rmd
+++ b/vignettes/write-to-disk.Rmd
@@ -8,6 +8,7 @@ output:
     toc_float: true
     theme: readable
 vignette: >
+  %\VignetteIndexEntry{Writing to disk}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---

--- a/vignettes/write-to-disk.Rmd
+++ b/vignettes/write-to-disk.Rmd
@@ -1,0 +1,33 @@
+---
+title: "Mocking writing to disk"
+author: "Scott Chamberlain"
+date: "`r Sys.Date()`"
+output:
+  html_document:
+    toc: true
+    toc_float: true
+    theme: readable
+vignette: >
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r echo=FALSE}
+knitr::opts_chunk$set(
+    comment = "#>",
+    collapse = TRUE,
+    warning = FALSE,
+    message = FALSE
+)
+```
+
+Request matching
+================
+
+```{r child='../man/rmdhunks/write-to-disk.Rmd', eval=TRUE} 
+```
+
+## More documentation
+
+Check out the [http testing book](https://books.ropensci.org/http-testing/) for a lot more documentation on `vcr`, `webmockr`, and `crul`
+

--- a/vignettes/write-to-disk.Rmd
+++ b/vignettes/write-to-disk.Rmd
@@ -25,6 +25,10 @@ knitr::opts_chunk$set(
 Request matching
 ================
 
+```{r setup}
+library("vcr")
+```
+
 ```{r child='../man/rmdhunks/write-to-disk.Rmd', eval=TRUE} 
 ```
 


### PR DESCRIPTION
This PR

* adds vignettes that are chapters in the HTTP testing book (then, the chapters from the HTTP testing book will read content from this repo)
* uses the lightswitch Rmd fragment in both the lightswitch vignette and lightswitch man page (less duplication).