### PR TITLE
make cassette names content re-usable

### DIFF
--- a/R/check_cassette_names.R
+++ b/R/check_cassette_names.R
@@ -7,29 +7,8 @@
 #' we use `immediate.=TRUE` so the warning happens at the top of your
 #' tests rather than you seeing it after tests have run (as would happen
 #' by default)
-#' @details This function is meant to be run during your tests, from a
-#' `setup-pkgname.R` file inside the `tests/testthat` directory. It only
-#' checks that cassette names are not duplicated. A helper function
-#' `check_cassette_name()` runs inside [insert_cassette()] that checks
-#' that cassettes do not have: spaces, file extensions, unaccepted
-#' characters (slashes)
-#' @section Cassette names:
-#' - Should be meaningful so that it's obvious to you what test/function
-#' they relate to. Meaningful names are important so that you can quickly
-#' determine to what test file or test block a cassette belongs. Note that
-#' vcr cannot check that your cassette names are meaningful.
-#' - Should not be duplicated. Duplicated cassette names would lead to
-#' a test using the wrong cassette.
-#' - Should not have spaces. Spaces can lead to problems in using file paths.
-#' - Should not include a file extension. vcr handles file extensions for
-#' the user.
-#' - Should not have illegal characters that can lead to problems in using
-#' file paths: '/', '?', '<', '>', '\\', ':', '*', '|', and '\"'
-#' - Should not have control characters, e.g., `\n`
-#' - Should not have just dots, e.g., `.` or `..`
-#' - Should not have Windows reserved words, e.g., `com1`
-#' - Should not have trailing dots
-#' - Should not be longer than 255 characters
+#' @includeRmd man/rmdhunks/cassette-names.Rmd details
+
 check_cassette_names <- function(pattern = "test-", behavior = "stop") {
   files <- list.files(".", pattern = pattern, full.names = TRUE)
   if (length(files) == 0) return()

--- a/R/insert_cassette.R
+++ b/R/insert_cassette.R
@@ -5,7 +5,7 @@ vcr__env <- new.env()
 #' @export
 #' @inheritParams use_cassette
 #' @inheritSection use_cassette Cassette options
-#' @inheritSection check_cassette_names Cassette names
+#' @inherit check_cassette_names details
 #' @seealso [use_cassette()], [eject_cassette()]
 #' @return an object of class `Cassette`
 #' @examples \dontrun{
@@ -28,7 +28,7 @@ vcr__env <- new.env()
 #' x$new_recorded_interactions # same, 1 interaction
 #' x$previously_recorded_interactions() # now not empty
 #' ## stub_registry now empty, eject() calls webmockr::disable(), which
-#' ## calls the disable method for each of crul and httr adadapters, 
+#' ## calls the disable method for each of crul and httr adadapters,
 #' ## which calls webmockr's remove_stubs() method for each adapter
 #' webmockr::stub_registry()
 #'

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -1,7 +1,7 @@
 #' Use a cassette to record HTTP requests
 #'
 #' @export
-#' @inheritSection check_cassette_names Cassette names
+#' @inherit check_cassette_names details
 #' @param name The name of the cassette. vcr will check this to ensure it
 #' is a valid file name. Not allowed: spaces, file extensions, control
 #' characters (e.g., `\n`), illegal characters ('/', '?', '<', '>', '\\', ':',

--- a/man/check_cassette_names.Rd
+++ b/man/check_cassette_names.Rd
@@ -19,32 +19,32 @@ by default)}
 Check cassette names
 }
 \details{
-This function is meant to be run during your tests, from a
-\code{setup-pkgname.R} file inside the \code{tests/testthat} directory. It only
-checks that cassette names are not duplicated. A helper function
-\code{check_cassette_name()} runs inside \code{\link[=insert_cassette]{insert_cassette()}} that checks
-that cassettes do not have: spaces, file extensions, unaccepted
-characters (slashes)
-}
-\section{Cassette names}{
-
+Cassette names:
 \itemize{
-\item Should be meaningful so that it's obvious to you what test/function
-they relate to. Meaningful names are important so that you can quickly
-determine to what test file or test block a cassette belongs. Note that
-vcr cannot check that your cassette names are meaningful.
-\item Should not be duplicated. Duplicated cassette names would lead to
-a test using the wrong cassette.
-\item Should not have spaces. Spaces can lead to problems in using file paths.
+\item Should be meaningful so that it’s obvious to you what test/function
+they relate to. Meaningful names are important so that you can
+quickly determine to what test file or test block a cassette
+belongs. Note that vcr cannot check that your cassette names are
+meaningful.
+\item Should not be duplicated. Duplicated cassette names would lead to a
+test using the wrong cassette.
+\item Should not have spaces. Spaces can lead to problems in using file
+paths.
 \item Should not include a file extension. vcr handles file extensions for
 the user.
-\item Should not have illegal characters that can lead to problems in using
-file paths: '/', '?', '<', '>', '\\', ':', '*', '|', and '\"'
-\item Should not have control characters, e.g., \verb{\\n}
+\item Should not have illegal characters that can lead to problems in
+using file paths: ‘/’, ‘?’, ‘<’, ‘>’, ‘\’, ‘:’, ’*‘,’|‘, and’"’
+\item Should not have control characters, e.g., \verb{\n}
 \item Should not have just dots, e.g., \code{.} or \code{..}
 \item Should not have Windows reserved words, e.g., \code{com1}
 \item Should not have trailing dots
 \item Should not be longer than 255 characters
 }
-}
 
+\code{vcr::check_cassette_names()} is meant to be run during your tests, from
+a \code{setup-pkgname.R} file inside the \code{tests/testthat} directory. It only
+checks that cassette names are not duplicated. A helper function
+\code{check_cassette_name()} runs inside
+\code{\link[=insert_cassette]{insert_cassette()}} that checks that cassettes
+do not have: spaces, file extensions, unaccepted characters (slashes)
+}

--- a/man/insert_cassette.Rd
+++ b/man/insert_cassette.Rd
@@ -68,6 +68,36 @@ an object of class \code{Cassette}
 \description{
 Insert a cassette to record HTTP requests
 }
+\details{
+Cassette names:
+\itemize{
+\item Should be meaningful so that it’s obvious to you what test/function
+they relate to. Meaningful names are important so that you can
+quickly determine to what test file or test block a cassette
+belongs. Note that vcr cannot check that your cassette names are
+meaningful.
+\item Should not be duplicated. Duplicated cassette names would lead to a
+test using the wrong cassette.
+\item Should not have spaces. Spaces can lead to problems in using file
+paths.
+\item Should not include a file extension. vcr handles file extensions for
+the user.
+\item Should not have illegal characters that can lead to problems in
+using file paths: ‘/’, ‘?’, ‘<’, ‘>’, ‘\’, ‘:’, ’*‘,’|‘, and’"’
+\item Should not have control characters, e.g., \verb{\n}
+\item Should not have just dots, e.g., \code{.} or \code{..}
+\item Should not have Windows reserved words, e.g., \code{com1}
+\item Should not have trailing dots
+\item Should not be longer than 255 characters
+}
+
+\code{vcr::check_cassette_names()} is meant to be run during your tests, from
+a \code{setup-pkgname.R} file inside the \code{tests/testthat} directory. It only
+checks that cassette names are not duplicated. A helper function
+\code{check_cassette_name()} runs inside
+\code{\link[=insert_cassette]{insert_cassette()}} that checks that cassettes
+do not have: spaces, file extensions, unaccepted characters (slashes)
+}
 \section{Cassette options}{
 
 
@@ -77,28 +107,6 @@ complete list of options and their default settings. You can override these
 options for a specific cassette by changing an argument's value to something
 other than \code{NULL} when calling either \code{insert_cassette()} or
 \code{use_cassette()}.
-}
-
-\section{Cassette names}{
-
-\itemize{
-\item Should be meaningful so that it's obvious to you what test/function
-they relate to. Meaningful names are important so that you can quickly
-determine to what test file or test block a cassette belongs. Note that
-vcr cannot check that your cassette names are meaningful.
-\item Should not be duplicated. Duplicated cassette names would lead to
-a test using the wrong cassette.
-\item Should not have spaces. Spaces can lead to problems in using file paths.
-\item Should not include a file extension. vcr handles file extensions for
-the user.
-\item Should not have illegal characters that can lead to problems in using
-file paths: '/', '?', '<', '>', '\\', ':', '*', '|', and '\"'
-\item Should not have control characters, e.g., \verb{\\n}
-\item Should not have just dots, e.g., \code{.} or \code{..}
-\item Should not have Windows reserved words, e.g., \code{com1}
-\item Should not have trailing dots
-\item Should not be longer than 255 characters
-}
 }
 
 \examples{
@@ -122,7 +130,7 @@ x$eject() # same as eject_cassette("leo5")
 x$new_recorded_interactions # same, 1 interaction
 x$previously_recorded_interactions() # now not empty
 ## stub_registry now empty, eject() calls webmockr::disable(), which
-## calls the disable method for each of crul and httr adadapters, 
+## calls the disable method for each of crul and httr adadapters,
 ## which calls webmockr's remove_stubs() method for each adapter
 webmockr::stub_registry()
 

--- a/man/rmdhunks/cassette-names.Rmd
+++ b/man/rmdhunks/cassette-names.Rmd
@@ -1,0 +1,25 @@
+Cassette names:
+
+- Should be meaningful so that it's obvious to you what test/function
+they relate to. Meaningful names are important so that you can quickly
+determine to what test file or test block a cassette belongs. Note that
+vcr cannot check that your cassette names are meaningful.
+- Should not be duplicated. Duplicated cassette names would lead to
+a test using the wrong cassette.
+- Should not have spaces. Spaces can lead to problems in using file paths.
+- Should not include a file extension. vcr handles file extensions for
+the user.
+- Should not have illegal characters that can lead to problems in using
+file paths: '/', '?', '<', '>', '\\', ':', '*', '|', and '\"'
+- Should not have control characters, e.g., `\n`
+- Should not have just dots, e.g., `.` or `..`
+- Should not have Windows reserved words, e.g., `com1`
+- Should not have trailing dots
+- Should not be longer than 255 characters
+
+`vcr::check_cassette_names()` is meant to be run during your tests, from a
+`setup-pkgname.R` file inside the `tests/testthat` directory. It only
+checks that cassette names are not duplicated. A helper function
+`check_cassette_name()` runs inside [insert_cassette()] that checks
+that cassettes do not have: spaces, file extensions, unaccepted
+characters (slashes)

--- a/man/use_cassette.Rd
+++ b/man/use_cassette.Rd
@@ -134,28 +134,6 @@ block.
 \code{use_cassette()} block starts on.
 }
 
-\section{Cassette names}{
-
-\itemize{
-\item Should be meaningful so that it's obvious to you what test/function
-they relate to. Meaningful names are important so that you can quickly
-determine to what test file or test block a cassette belongs. Note that
-vcr cannot check that your cassette names are meaningful.
-\item Should not be duplicated. Duplicated cassette names would lead to
-a test using the wrong cassette.
-\item Should not have spaces. Spaces can lead to problems in using file paths.
-\item Should not include a file extension. vcr handles file extensions for
-the user.
-\item Should not have illegal characters that can lead to problems in using
-file paths: '/', '?', '<', '>', '\\', ':', '*', '|', and '\"'
-\item Should not have control characters, e.g., \verb{\\n}
-\item Should not have just dots, e.g., \code{.} or \code{..}
-\item Should not have Windows reserved words, e.g., \code{com1}
-\item Should not have trailing dots
-\item Should not be longer than 255 characters
-}
-}
-
 \examples{
 \dontrun{
 library(vcr)


### PR DESCRIPTION
What's not optimal is that includeRmd does not work for user-defined sections so I had to remove the section title. https://roxygen2.r-lib.org/articles/rd.html#sections-1

I then want to use this fragment in the book for https://github.com/ropensci-books/http-testing/issues/17