### PR TITLE
simplify vcr_test_path()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     yaml,
     R6,
     base64enc,
-    here
+    rprojroot
 Suggests:
     roxygen2 (>= 7.0.2),
     jsonlite,

--- a/R/vcr_test_path.R
+++ b/R/vcr_test_path.R
@@ -5,7 +5,7 @@
 #'
 #' @param ...	Character vectors giving path component. each character string
 #' gets added on to the path, e.g., `vcr_test_path("a", "b")` becomes
-#' `tests/a/b` when run from the root of the package.
+#' `tests/a/b` relative to the root of the package.
 #'
 #' @return A character vector giving the path
 #' @export
@@ -13,22 +13,14 @@
 #' if (interactive()) {
 #' vcr_test_path("fixtures")
 #' }
-# Adapted from https://github.com/r-lib/testthat/blob/45a9c705402bd51af29b9d999e587ba789f6203f/R/test-path.R#L1
 vcr_test_path <- function(...) {
-  if (any(!nzchar(...))) {
-    stop("Please use non empty path elements.")
+  if (missing(...)) stop("Please provide a directory name.")
+  if (any(!nzchar(...))) stop("Please use non empty path elements.")
+  root <- rprojroot::is_r_package
+  path <- root$find_file("tests", ...)
+  if (!dir.exists(path)){
+    message("could not find ", path, "; creating it")
+    dir.create(path)
   }
-
-  if (identical(Sys.getenv("TESTTHAT"), "true") &&
-      !isTRUE(getOption("testthat_interactive"))) {
-    if (missing(...)) {
-      "../."
-    } else {
-      file.path("..", ...)
-    }
-  } else {
-    path <- here::here("tests", ...)
-    if (!dir.exists(path)) message("could not find ", path, "; creating it")
-    path
-  }
+  path
 }

--- a/man/vcr_test_path.Rd
+++ b/man/vcr_test_path.Rd
@@ -9,7 +9,7 @@ vcr_test_path(...)
 \arguments{
 \item{...}{Character vectors giving path component. each character string
 gets added on to the path, e.g., \code{vcr_test_path("a", "b")} becomes
-\code{tests/a/b} when run from the root of the package.}
+\code{tests/a/b} relative to the root of the package.}
 }
 \value{
 A character vector giving the path

--- a/tests/testthat/test-vcr_test_path.R
+++ b/tests/testthat/test-vcr_test_path.R
@@ -1,7 +1,23 @@
 test_that("vcr_test_path works", {
-  expect_match(vcr_test_path("fixtures"), "../fixtures")
-  withr::local_envvar(c("TESTTHAT" = "false"))
-  expect_match(vcr_test_path("fixtures"), "tests/fixtures")
-  expect_message(vcr_test_path("fixtures"), "creating")
-  expect_error(vcr_test_path("", "a"), "non empty")
+  skip_on_cran()
+
+  # setup
+  dir <- file.path(tempdir(), "bunny")
+  invisible(make_pkg(dir))
+  dir.create(file.path(dir, "tests"), recursive = TRUE)
+  withr::local_dir(dir)
+
+  # test
+  expect_message(pth <- vcr_test_path("fixtures"), "creating", fixed = TRUE)
+  expect_match(pth, "tests/fixtures", fixed = TRUE)
+  expect_match(
+    list.dirs(file.path(dir, "tests"), FALSE, FALSE),
+    "fixtures",
+    fixed = TRUE
+  )
+  expect_error(vcr_test_path("", "a"), "non empty", fixed = TRUE)
+  expect_error(vcr_test_path(), "provide", fixed = TRUE)
+
+  # cleanup
+  unlink(dir, TRUE, TRUE)
 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This simplifies `vcr_test_path()` as discussed in #229. It uses {rprojroot} instead of {here}. It also adjusts `vcr_test_path()`-related tests accordingly.

## Related Issue
#228, #229
