### PR TITLE
vcr_test_path() fix: look for 'tests' dir instead of DESCRIPTION

### DIFF
--- a/R/vcr_test_path.R
+++ b/R/vcr_test_path.R
@@ -16,7 +16,7 @@
 vcr_test_path <- function(...) {
   if (missing(...)) stop("Please provide a directory name.")
   if (any(!nzchar(...))) stop("Please use non empty path elements.")
-  root <- rprojroot::is_r_package
+  root <- rprojroot::has_dir("tests")
   path <- root$find_file("tests", ...)
   if (!dir.exists(path)){
     message("could not find ", path, "; creating it")


### PR DESCRIPTION
- DESCRIPTION is not available for tests run by R CMD check, #235

Both `devtools::test()` and `devtools::check()` seem to run successfully with this change. 

Caveat: If `vcr_test_path()` is run from a file `setup-pkg.R` in `./tests/testthat/` (i.e. the recommended setup, AFAIU),  `has_dir()` is starting to search for the `tests` dir from `./tests/testthat/` and go further up the dir tree. As a result, it will use `./tests/testthat/tests/` or `./tests/tests/` as a "root" dir should those exist and the test path will start from there.  