### PR TITLE
set vcr_test_path() relative to testthat dir

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,4 +52,4 @@ Suggests:
 X-schema.org-applicationCategory: Web
 X-schema.org-keywords: http, https, API, web-services, curl, mock, mocking, http-mocking, testing, testing-tools, tdd
 X-schema.org-isPartOf: https://ropensci.org
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+vcr 1.0.3
+=========
+
+### BUG FIXES
+
+* fix to `vcr_test_path()` to find root package path correctly with R 4.2 on Windows (#242) (#243)
+
 vcr 1.0.2
 =========
 

--- a/R/vcr_test_path.R
+++ b/R/vcr_test_path.R
@@ -3,6 +3,8 @@
 #' This function, similar to `testthat::test_path()`, is designed to work both
 #' interactively and during tests, locating files in the `tests/` directory.
 #'
+#' @note `vcr_test_path()` assumes you are using testthat for your unit tests.
+#'
 #' @param ...	Character vectors giving path component. each character string
 #' gets added on to the path, e.g., `vcr_test_path("a", "b")` becomes
 #' `tests/a/b` relative to the root of the package.

--- a/R/vcr_test_path.R
+++ b/R/vcr_test_path.R
@@ -6,9 +6,6 @@
 #' @param ...	Character vectors giving path component. each character string
 #' gets added on to the path, e.g., `vcr_test_path("a", "b")` becomes
 #' `tests/a/b` relative to the root of the package.
-#' 
-#' @note Beware if you have more than one `tests` directories in your package
-#' root. This may not work as intended if that is the case.
 #'
 #' @return A character vector giving the path
 #' @export
@@ -19,8 +16,10 @@
 vcr_test_path <- function(...) {
   if (missing(...)) stop("Please provide a directory name.")
   if (any(!nzchar(...))) stop("Please use non empty path elements.")
-  root <- rprojroot::has_dir("tests")
-  path <- root$find_file("tests", ...)
+
+  # dirname () moves up one level from testthat dir
+  root <- dirname(rprojroot::find_testthat_root_file())
+  path <- file.path(root, ...)
   if (!dir.exists(path)){
     message("could not find ", path, "; creating it")
     dir.create(path)

--- a/man/vcr_test_path.Rd
+++ b/man/vcr_test_path.Rd
@@ -18,6 +18,9 @@ A character vector giving the path
 This function, similar to \code{testthat::test_path()}, is designed to work both
 interactively and during tests, locating files in the \verb{tests/} directory.
 }
+\note{
+\code{vcr_test_path()} assumes you are using testthat for your unit tests.
+}
 \examples{
 if (interactive()) {
 vcr_test_path("fixtures")

--- a/man/vcr_test_path.Rd
+++ b/man/vcr_test_path.Rd
@@ -18,10 +18,6 @@ A character vector giving the path
 This function, similar to \code{testthat::test_path()}, is designed to work both
 interactively and during tests, locating files in the \verb{tests/} directory.
 }
-\note{
-Beware if you have more than one \code{tests} directories in your package
-root. This may not work as intended if that is the case.
-}
 \examples{
 if (interactive()) {
 vcr_test_path("fixtures")

--- a/tests/testthat/test-vcr_test_path.R
+++ b/tests/testthat/test-vcr_test_path.R
@@ -1,23 +1,53 @@
-test_that("vcr_test_path works", {
+test_that("vcr_test_path works with testthat", {
   skip_on_cran()
 
   # setup
   dir <- file.path(tempdir(), "bunny")
-  invisible(make_pkg(dir))
-  dir.create(file.path(dir, "tests"), recursive = TRUE)
+  dir.create(file.path(dir, "tests", "testthat"), recursive = TRUE)
   withr::local_dir(dir)
 
   # test
   expect_message(pth <- vcr_test_path("fixtures"), "creating", fixed = TRUE)
-  expect_match(pth, "tests/fixtures", fixed = TRUE)
+  expect_match(pth, file.path("tests", "fixtures"), fixed = TRUE)
   expect_match(
-    list.dirs(file.path(dir, "tests"), FALSE, FALSE),
+    list.dirs(file.path(dir, "tests"), full.names = FALSE, recursive = FALSE),
     "fixtures",
-    fixed = TRUE
+    fixed = TRUE,
+    all = FALSE
   )
-  expect_error(vcr_test_path("", "a"), "non empty", fixed = TRUE)
-  expect_error(vcr_test_path(), "provide", fixed = TRUE)
 
   # cleanup
-  unlink(dir, TRUE, TRUE)
+  unlink(dir, recursive = TRUE, force = TRUE)
+})
+
+test_that("vcr_test_path works with testthat in a dir that isn't `tests`", {
+  skip_on_cran()
+
+  # setup
+  dir <- file.path(tempdir(), "tests_xyz")
+  dir.create(file.path(dir, "testthat"), recursive = TRUE)
+  withr::local_dir(dir)
+
+  # test
+  expect_message(pth <- vcr_test_path("fixtures"), "creating", fixed = TRUE)
+  expect_match(pth, file.path("fixtures"), fixed = TRUE)
+  expect_match(
+    list.dirs(file.path(dir), full.names = FALSE, recursive = FALSE),
+    "fixtures",
+    fixed = TRUE,
+    all = FALSE
+  )
+
+  # cleanup
+  unlink(dir, recursive = TRUE, force = TRUE)
+})
+
+test_that("vcr_test_path errors with wrongly specified paths", {
+  skip_on_cran()
+
+  ## Paths may not be empty strings
+  expect_error(vcr_test_path("", "a"), "non empty", fixed = TRUE)
+  ## User must provide a dir name
+  expect_error(vcr_test_path(), "provide", fixed = TRUE)
+
 })


### PR DESCRIPTION
`vcr_test_path()` now looks for the `testthat` dir instead of `tests`, because the latter may not be present during `R CMD check`. 
`fixtures` (or however the folder is called by the user) is then put on the same level as `testthat` (instead of one level up from `tests`). 

fixes #242 (hopefully)
