### PR TITLE
Fix URI mismatch with httr #240

### DIFF
--- a/R/request_matcher_registry.R
+++ b/R/request_matcher_registry.R
@@ -45,13 +45,17 @@ RequestMatcherRegistry <- R6::R6Class(
     #' @note r1=from new request; r2=from recorded interaction
     register_built_ins = function() {
       self$register("method", function(r1, r2) r1$method == r2$method)
-      self$register("uri", function(r1, r2) query_params_remove_str(r1$uri) == r2$uri)
+      self$register("uri", function(r1, r2)
+              identical(
+                curl::curl_unescape(query_params_remove_str(r1$uri)), curl::curl_unescape(r2$uri))
+              )
       self$register("body", function(r1, r2) identical(r1$body, r2$body))
       self$register('headers', function(r1, r2) identical(r1$headers, r2$headers))
       self$register("host", function(r1, r2) identical(r1$host, r2$host))
       self$register("path", function(r1, r2)
         identical(sub("/$", "", r1$path), sub("/$", "", r2$path)))
-      self$register("query", function(r1, r2) identical(r1$query, r2$query))
+      self$register("query", function(r1, r2)
+        identical(curl::curl_unescape(r1$query), curl::curl_unescape(r2$query)))
       self$try_to_register_body_as_json()
     },
 

--- a/tests/testthat/test-ause_cassette_match_query.R
+++ b/tests/testthat/test-ause_cassette_match_query.R
@@ -1,0 +1,25 @@
+
+url <- "https://httpbin.org/get?update=2022-01-01T00:00:00&p2=ok"
+req_crul <- function(url) {
+    tmp <- crul::HttpClient$new(url)$get()
+}
+req_httr <- function(url) {
+    tmp <- httr::GET(url)
+}
+
+test_that('request matching is not sensitive to escaping special characters', {
+  skip_on_cran()
+  skip_on_ci()
+  # run twice the request with curl (curl does not escape)
+  aa <- vcr::use_cassette('get_crul_match', {
+    req_crul(url)
+  }, match_requests_on = c("method", "uri", "query"))
+  res <- req_crul(url)
+  expect_true(res$status_code == 200)
+  # run twice the request with httr (httr does escape on parameters)
+  bb <- vcr::use_cassette('get_httr_match', {
+    req_httr(url)
+  }, match_requests_on = c("method", "uri", "query"))
+  res <- req_httr(url)
+  expect_true(res$status_code == 200)
+})


### PR DESCRIPTION
Hi @sckott, 

Hope you're doing well! 

This is a proposition to fix #240. The reason of the mismatch is that the request matchers are not accounting for potential escaping of special character and `httr` actually applies such escaping on URI parameters:

```R
httr:::compose_query
function (elements)
{
    if (length(elements) == 0) {
        return("")
    }
    if (!all(has_name(elements))) {
        stop("All components of query must be named", call. = FALSE)
    }
    stopifnot(is.list(elements))
    elements <- compact(elements)
    names <- curl::curl_escape(names(elements))
    encode <- function(x) {
        if (inherits(x, "AsIs")) 
            return(x)
        curl::curl_escape(x)
    }
    values <- vapply(elements, encode, character(1))
    paste0(names, "=", values, collapse = "&")
} 
```

So to account for this, I use ``curl::curl_unescape()` in the request matchers for URI and query, I also added unit tests for this,

Let me know what do you think! 