### PR TITLE
Use again body_from for the body of the response

### DIFF
--- a/R/response_class.R
+++ b/R/response_class.R
@@ -42,7 +42,7 @@
 #' x$headers$`content-length` # = NULL
 #' x$update_content_length_header() # no change, b/c header doesn't exist
 #' x$headers$`content-length` # = NULL
-#' 
+#'
 #' ## example 3
 #' ### content-length header present, and does change
 #' body <- " Hello World "
@@ -147,8 +147,8 @@ VcrResponse <- R6::R6Class(
       VcrResponse$new(
         hash[["status"]],
         hash[["headers"]],
-        hash[["body"]],
-        # body_from(hash[["body"]]),
+        # hash[["body"]],
+        body_from(hash[["body"]]),
         hash[["http_version"]],
         hash[["adapater_metadata"]],
         hash[["disk"]]

--- a/tests/testthat/test-issues.R
+++ b/tests/testthat/test-issues.R
@@ -1,0 +1,6 @@
+test_that('issue 249 is correctly handled.', {
+  vcr::use_cassette('get_401', {
+    res <- httr::GET('https://httpbin.org/status/401')
+  })
+  expect_true(res$status_code == 401)
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR reverts some changes as discussed in #249 to handle the body again with the `body_from` function and adds a new test for it.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
#249 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

I'm not sure how to add tests for this, but I added the test as reported in #249 in a new file test-issues.

Tests and checks pass but I'm not sure if the issue is fully resolved. 
