### PR TITLE
setup-vcr.R -> helper-vcr.R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+development version
+=========
+
+* `use_vcr()` now creates a test helper file called `helper-vcr.R` instead of `setup-pkgname.R`. 
+  We are reverting the change from version 0.6.0 and now recommend the use of `helper-*.R` again, so that the vcr setup [is loaded with `devtools::load_all()`](https://testthat.r-lib.org/reference/test_dir.html#special-files). 
+  That way your vcr-enabled tests also work when run interactively (#244).
+
 vcr 1.1.0
 =========
 

--- a/R/vcr_setup.R
+++ b/R/vcr_setup.R
@@ -106,17 +106,18 @@ use_vcr <- function(dir = ".", verbose = TRUE) {
   }
 
   # add helper-pkgname.R to tests/testthat/
-  hf <- file.path(dir, sprintf("tests/testthat/setup-%s.R", pkg))
-  if (!file.exists(hf)) {
-    file.create(hf, showWarnings = FALSE)
+  rel_hf <- "tests/testthat/helper-vcr.R"
+  abs_hf <- file.path(dir, rel_hf)
+  if (!file.exists(abs_hf)) {
+    file.create(abs_hf, showWarnings = FALSE)
   }
-  if (!any(grepl("vcr_configure", readLines(hf)))) {
+  if (!any(grepl("vcr_configure", readLines(abs_hf)))) {
     if (verbose) vcr_cat_line(paste0("Adding vcr config to ",
-      crayon::blue(sprintf("tests/testthat/setup-%s.R", pkg))))
-    cat(vcr_text$config, file = hf, append = TRUE)
+      crayon::blue(rel_hf)))
+    cat(vcr_text$config, file = abs_hf, append = TRUE)
   } else {
     if (verbose) vcr_cat_info(paste0("vcr config appears to be already setup in ",
-      crayon::blue(sprintf("tests/testthat/setup-%s.R", pkg))))
+      crayon::blue(rel_hf)))
   }
 
   # add dummy test file with example of use_cassette()

--- a/man/rmdhunks/cassette-names.Rmd
+++ b/man/rmdhunks/cassette-names.Rmd
@@ -17,11 +17,7 @@ file paths: `/`, `?`, `<`, `>`, `\\`, `:`, `*`, `|`, and `\"`
 - Should not have trailing dots
 - Should not be longer than 255 characters
 
-`vcr::check_cassette_names()` is meant to be run during your tests, from a
-`setup-pkgname.R` file inside the `tests/testthat` directory. It only
-checks that cassette names are not duplicated. Note that if you do 
-need to have duplicated cassette names you can do so by using the
-`allowed_duplicates` parameter in `check_cassette_names()`. A helper function
-`check_cassette_names()` runs inside [insert_cassette()] that checks
-that cassettes do not have: spaces, file extensions, unaccepted
-characters (slashes)
+`vcr::check_cassette_names()` is meant to be run during your tests, from a [`helper-*.R` file](https://testthat.r-lib.org/reference/test_dir.html#special-files) inside the `tests/testthat` directory. 
+It only checks that cassette names are not duplicated.
+Note that if you do need to have duplicated cassette names you can do so by using the `allowed_duplicates` parameter in `check_cassette_names()`. 
+A helper function `check_cassette_names()` runs inside [insert_cassette()] that checks that cassettes do not have: spaces, file extensions, unaccepted characters (slashes).

--- a/man/rmdhunks/setup.Rmd
+++ b/man/rmdhunks/setup.Rmd
@@ -17,7 +17,7 @@ This will:
 * setup a config file for `vcr`
 * add an example test file for `vcr`
 * make a `.gitattributes` file with settings for `vcr` 
-* make a `./tests/testthat/setup-vcr.R` file
+* make a `./tests/testthat/helper-vcr.R` file
 
 What you will see in the R console:
 
@@ -28,7 +28,7 @@ What you will see in the R console:
 ✓ Creating directory: ./tests/testthat  
 ◉ Looking for testthat.R file or similar  
 ✓ tests/testthat.R: added  
-✓ Adding vcr config to tests/testthat/setup-vcr.example.R  
+✓ Adding vcr config to tests/testthat/helper-vcr.example.R  
 ✓ Adding example test file tests/testthat/test-vcr_example.R  
 ✓ .gitattributes: added  
 ◉ Learn more about `vcr`: https://books.ropensci.org/http-testing
@@ -40,7 +40,7 @@ Secrets often turn up in API work. A common example is an API key.
 `vcr` saves responses from APIs as YAML files, and this will include your secrets unless you indicate to `vcr` what they are and how to protect them.
 The `vcr_configure` function has the `filter_sensitive_data` argument function for just this situation. 
 The `filter_sensitive_data` argument takes a named list where the _name_ of the list is the string that will be used in the recorded cassettes _instead of_ the secret, which is the list _item_. 
-`vcr` will manage the replacement of that for you, so all you need to do is to edit your `setup-vcr.R` file like this:
+`vcr` will manage the replacement of that for you, so all you need to do is to edit your [`helper-vcr.R` file](https://testthat.r-lib.org/reference/test_dir.html#special-files) like this:
 
 ```r
 library("vcr") # *Required* as vcr is set up on loading
@@ -88,7 +88,7 @@ Furthermore, as by default requests matching does not include the API key, thing
 E.g. to have tests pass on continuous integration for external pull requests to your code repository.
 
 * vcr does not need an actual API key for requests once the cassettes are created, as no real requests will be made.
-* you still need to fool your _package_ into believing there is an API key as it will construct requests with it. So add the following lines to a testthat setup file (e.g. `tests/testthat/setup-vcr.R`)
+* you still need to fool your _package_ into believing there is an API key as it will construct requests with it. So add the following lines to a testthat setup file (e.g. `tests/testthat/helper-vcr.R`)
 
 ```r
 if (!nzchar(Sys.getenv("APIKEY"))) {

--- a/tests/testthat/test-use_vcr.R
+++ b/tests/testthat/test-use_vcr.R
@@ -11,8 +11,8 @@ test_that("use_vcr works", {
   expect_null(res)
   expect_true(dir.exists(file.path(dir, "tests")))
   expect_true(file.exists(file.path(dir, "tests/testthat.R")))
-  expect_true(file.exists(file.path(dir, "tests/testthat/setup-foobar.R")))
-  help <- paste0(readLines(file.path(dir, "tests/testthat/setup-foobar.R")),
+  expect_true(file.exists(file.path(dir, "tests/testthat/helper-vcr.R")))
+  help <- paste0(readLines(file.path(dir, "tests/testthat/helper-vcr.R")),
     collapse = " ")
   expect_match(help, "vcr::vcr_configure")
   expect_match(help, "vcr::check_cassette_names")

--- a/tests/testthat/test-write_disk_path_package_context.R
+++ b/tests/testthat/test-write_disk_path_package_context.R
@@ -26,7 +26,7 @@ invisible(vcr::vcr_configure(
   write_disk_path = "../files"
 ))
 vcr::check_cassette_names()'
-  cat(z, file = file.path(dir, "tests/testthat/setup-rabbit.R"))
+  cat(z, file = file.path(dir, "tests/testthat/helper-rabbit.R"))
 
   file_string <- '{
   "args": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This changes all references to setup-vcr.R to helper-vcr.R, as discussed in #244. `use_vcr()` also now creates a `helper-vcr.R` file. 

cc @maelle 