### PR TITLE
Update example packages in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -117,6 +117,10 @@ The canonical `vcr` (in Ruby) lists ports in other languages at <https://github.
 * [wikitaxa][]
 * [worrms][]
 * [ritis][]
+* [qualtRics][]
+* [rtweet][]
+* [rtoot][]
+* [allcontributors][]
 
 ## Contributors
 
@@ -139,3 +143,7 @@ The canonical `vcr` (in Ruby) lists ports in other languages at <https://github.
 [wikitaxa]: https://github.com/ropensci/wikitaxa
 [worrms]: https://github.com/ropensci/worrms
 [ritis]: https://github.com/ropensci/ritis
+[qualtRics]: https://github.com/ropensci/qualtRics
+[rtweet]: https://github.com/ropensci/rtweet
+[rtoot]: https://github.com/schochastics/rtoot
+[allcontributors]: https://github.com/ropenscilabs/allcontributors

--- a/README.Rmd
+++ b/README.Rmd
@@ -116,9 +116,6 @@ The canonical `vcr` (in Ruby) lists ports in other languages at <https://github.
 * [bold][]
 * [wikitaxa][]
 * [worrms][]
-* [microdemic][]
-* [zbank][]
-* [rplos][]
 * [ritis][]
 
 ## Contributors
@@ -141,7 +138,4 @@ The canonical `vcr` (in Ruby) lists ports in other languages at <https://github.
 [bold]: https://github.com/ropensci/bold
 [wikitaxa]: https://github.com/ropensci/wikitaxa
 [worrms]: https://github.com/ropensci/worrms
-[microdemic]: https://github.com/ropensci/microdemic
-[zbank]: https://github.com/ropenscilabs/zbank
-[rplos]: https://github.com/ropensci/rplos
 [ritis]: https://github.com/ropensci/ritis

--- a/README.Rmd
+++ b/README.Rmd
@@ -111,16 +111,16 @@ The canonical `vcr` (in Ruby) lists ports in other languages at <https://github.
 
 ## Example packages using vcr
 
-* [rgbif][]
-* [rredlist][]
+* [allcontributors][]
 * [bold][]
+* [qualtRics][]
+* [rgbif][]
+* [ritis][]
+* [rredlist][]
+* [rtoot][]
+* [rtweet][]
 * [wikitaxa][]
 * [worrms][]
-* [ritis][]
-* [qualtRics][]
-* [rtweet][]
-* [rtoot][]
-* [allcontributors][]
 
 ## Contributors
 
@@ -135,15 +135,15 @@ The canonical `vcr` (in Ruby) lists ports in other languages at <https://github.
 * Get citation information for `vcr` in R doing `citation(package = 'vcr')`
 * Please note that this package is released with a [Contributor Code of Conduct](https://ropensci.org/code-of-conduct/). By contributing to this project, you agree to abide by its terms.
 
-[webmockr]: https://docs.ropensci.org/webmockr/
-[crul]: https://docs.ropensci.org/crul/
-[rgbif]: https://github.com/ropensci/rgbif
-[rredlist]: https://github.com/ropensci/rredlist
+[allcontributors]: https://github.com/ropenscilabs/allcontributors
 [bold]: https://github.com/ropensci/bold
+[crul]: https://docs.ropensci.org/crul/
+[qualtRics]: https://github.com/ropensci/qualtRics
+[rgbif]: https://github.com/ropensci/rgbif
+[ritis]: https://github.com/ropensci/ritis
+[rredlist]: https://github.com/ropensci/rredlist
+[rtoot]: https://github.com/schochastics/rtoot
+[rtweet]: https://github.com/ropensci/rtweet
+[webmockr]: https://docs.ropensci.org/webmockr/
 [wikitaxa]: https://github.com/ropensci/wikitaxa
 [worrms]: https://github.com/ropensci/worrms
-[ritis]: https://github.com/ropensci/ritis
-[qualtRics]: https://github.com/ropensci/qualtRics
-[rtweet]: https://github.com/ropensci/rtweet
-[rtoot]: https://github.com/schochastics/rtoot
-[allcontributors]: https://github.com/ropenscilabs/allcontributors

--- a/README.Rmd
+++ b/README.Rmd
@@ -57,7 +57,7 @@ Check out the [HTTP testing book](https://books.ropensci.org/http-testing) and t
 
 ## Supported HTTP libraries
 
-* [crul](https://docs.ropensci.org/crul/)
+* [crul][]
 * [httr](https://httr.r-lib.org/)
 
 ## Getting Started


### PR DESCRIPTION
This updates the references to example packages in the readme, i.e. 

- remove archived example packages using vcr
- add new packages: allcontributors, rtweet, rtoot
- sort references alphabetically