### PR TITLE
Implement `local_vcr_configure()` helper

### DIFF
--- a/R/configuration.R
+++ b/R/configuration.R
@@ -464,7 +464,7 @@ VCRConfig <- R6::R6Class(
 
     # return current configuration as a list
     as_list = function() {
-      setNames(mget(names(private), private), self$fields())
+      stats::setNames(mget(names(private), private), self$fields())
     },
 
     print = function(...) {

--- a/R/configuration.R
+++ b/R/configuration.R
@@ -175,7 +175,7 @@ vcr_configure <- function(...) {
     params <- params[!invalid]
   }
 
-  if (length(params) == 0) return(vcr_c)
+  if (length(params) == 0) return(invisible(vcr_c$as_list()))
 
   # TODO: Is this still the right place to change these settings?
   ignore_hosts <- params$ignore_hosts
@@ -186,10 +186,17 @@ vcr_configure <- function(...) {
     if (ignore_localhost) x$ignore_localhost()
   }
 
+  vcr_config_set(params)
+}
+
+vcr_config_set <- function(params) {
+  old <- vcr_c$as_list()[names(params)]
+
   for (i in seq_along(params)) {
     vcr_c[[names(params)[i]]] <- params[[i]]
   }
-  return(vcr_c)
+
+  invisible(old)
 }
 
 #' @export

--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -1,6 +1,11 @@
 tmpdir <- tempdir()
 library(vcr)
 
+local_vcr_configure <- function(..., .frame = parent.frame()) {
+  old <- vcr_configure(...)
+  withr::defer(vcr_config_set(old), envir = .frame)
+}
+
 # define and restore consistent configuration options for tests
 vcr_test_configuration <- function(
   dir = tmpdir,

--- a/tests/testthat/test-RequestHandler.R
+++ b/tests/testthat/test-RequestHandler.R
@@ -1,7 +1,5 @@
 skip_on_cran()
 
-vcr_configure(dir = tempdir())
-
 test_that("RequestHandlerHttr", {
   load("httr_obj.rda")
 

--- a/tests/testthat/test-cassette_options.R
+++ b/tests/testthat/test-cassette_options.R
@@ -17,7 +17,7 @@ test_that("Cassette options", {
   ## expect warning from empty cassette checker
   expect_warning(cl$eject())
 
-  vcr_configure(warn_on_empty_cassette = FALSE)
+  local_vcr_configure(warn_on_empty_cassette = FALSE)
   cl <- Cassette$new(name = "stuff2")
   ## expect NO warning when warn_on_empty_cassette=FALSE
   expect_warning(cl$eject(), NA)
@@ -25,5 +25,3 @@ test_that("Cassette options", {
 
 # cleanup
 unlink(file.path(vcr_configuration()$dir, "stuff.yml"))
-
-vcr_configure_reset()

--- a/tests/testthat/test-configuration.R
+++ b/tests/testthat/test-configuration.R
@@ -1,8 +1,3 @@
-on.exit({
-  vcr_configure_reset()
-  vcr_configure(dir = tmpdir, write_disk_path = file.path(tmpdir, "files"))
-})
-
 test_that("VCRConfig", {
   cl <- vcr_configuration()
   expect_s3_class(cl, "R6")
@@ -23,9 +18,20 @@ test_that("config fails well with invalid request matchers", {
   )
 })
 
+test_that("returns previous values", {
+  local_vcr_configure(dir = "dir1", record = "none")
+
+  old <- vcr_configure(dir = "dir2", record = "once")
+  expect_equal(old, list(dir = "dir1", record = "none"))
+})
+
+test_that("if called with no args returns a list of all args", {
+  out <- vcr_configure()
+  expect_equal(out, vcr_c$as_list())
+})
+
 test_that("vcr_configure() only affects settings passed as arguments", {
-  vcr_configure_reset()
-  vcr_configure(dir = "olddir", record = "none")
+  local_vcr_configure(dir = "olddir", record = "none")
   config1 <- vcr_c$clone()
 
   vcr_configure(dir = "newdir")
@@ -39,6 +45,8 @@ test_that("vcr_configure() only affects settings passed as arguments", {
 })
 
 test_that("warnings are thrown for invalid parameters", {
+  local_vcr_configure()
+
   expect_warning(
     vcr_configure(foo = "bar"),
     "The following configuration parameters are not valid"

--- a/tests/testthat/test-filter-sensitive-strings.R
+++ b/tests/testthat/test-filter-sensitive-strings.R
@@ -9,7 +9,7 @@ test_that("filter sensitive strings", {
   expect_identical(sensitive_remove(x), x)
 
   # vcr_c$filter_sensitive_data is not NULL
-  vcr_configure(
+  local_vcr_configure(
     filter_sensitive_data = list("<<my-key>>" = "234223){@%!kl]")
   )
   expect_type(vcr_c$filter_sensitive_data, "list")
@@ -27,7 +27,7 @@ test_that("filter sensitive regex strings", {
   expect_identical(sensitive_remove(x), x)
 
   # vcr_c$filter_sensitive_data is not NULL
-  vcr_configure(
+  local_vcr_configure(
     filter_sensitive_data_regex = list("<<my-key>>" = "foo[0-9]+bar")
   )
   expect_type(vcr_c$filter_sensitive_data_regex, "list")
@@ -41,8 +41,8 @@ test_that("filter sensitive regex strings", {
 
 test_that("filter sensitive data strips leading/trailing single/double quotes", {
   Sys.setenv(MY_KEY_ON_GH_ACTIONS = "\"ab123c\"")
-  tmpdir <- tempdir()
-  vcr_configure(
+  tmpdir <- withr::local_tempdir()
+  local_vcr_configure(
     dir = tmpdir,
     filter_sensitive_data = list(
       "<somekey>" = Sys.getenv("MY_KEY_ON_GH_ACTIONS")
@@ -70,6 +70,3 @@ test_that("filter sensitive data strips leading/trailing single/double quotes", 
   # unset
   Sys.unsetenv("MY_KEY_ON_GH_ACTIONS")
 })
-
-# reset config
-vcr_configure_reset()

--- a/tests/testthat/test-quiet.R
+++ b/tests/testthat/test-quiet.R
@@ -1,11 +1,10 @@
-vcr_configure_reset()
-
-tmpdir <- tempdir()
-vcr_configure(dir = tmpdir)
-
 test_that("quiet works", {
   library(crul)
   con <- HttpClient$new(hb())
+
+  tmpdir <- withr::local_tempdir()
+  local_vcr_configure(dir = tmpdir)
+
   # default: quiet=TRUE
   expect_true(vcr_configuration()$quiet)
   expect_message(
@@ -22,7 +21,7 @@ test_that("quiet works", {
   )
 
   # quiet=FALSE
-  vcr_configure(quiet = FALSE)
+  local_vcr_configure(quiet = FALSE)
   expect_false(vcr_configuration()$quiet)
   webmockr::webmockr_disable_net_connect()
   expect_message(
@@ -38,5 +37,3 @@ test_that("quiet works", {
     "disabled"
   )
 })
-
-vcr_configure_reset()


### PR DESCRIPTION
This required changing `vcr_configure()` to make it work like `options()`, namely if called with no options return a list of all options, and if called with some new options, return the previous values of those options.

I used it a few test just to get a sense for how it works.
