### PR TITLE
Eliminate `vcr_test_configuration()`

### DIFF
--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -1,22 +1,9 @@
-tmpdir <- tempdir()
 library(vcr)
 
 local_vcr_configure <- function(..., .frame = parent.frame()) {
   old <- vcr_configure(...)
   withr::defer(vcr_config_set(old), envir = .frame)
 }
-
-# define and restore consistent configuration options for tests
-vcr_test_configuration <- function(
-  dir = tmpdir,
-  write_disk_path = file.path(tmpdir, "files"),
-  ...
-) {
-  vcr_configure_reset()
-  vcr_configure(dir = dir, write_disk_path = write_disk_path, ...)
-}
-
-vcr_test_configuration()
 
 desc_text <- "Package: %s
 Title: Does A Thing

--- a/tests/testthat/test-RequestIgnorer.R
+++ b/tests/testthat/test-RequestIgnorer.R
@@ -79,33 +79,17 @@ test_that("RequestIgnorer usage: w/ real requests", {
 test_that("RequestIgnorer usage: w/ vcr_configure() usage", {
   skip_on_cran()
 
-  on.exit({
-    files <- c(
-      "test_ignore_host.yml",
-      "test_ignore_host_ignored.yml",
-      "test_ignore_localhost_ignored.yml",
-      "test_ignore_localhost.yml"
-    )
-    unlink(file.path(vcr_configuration()$dir, files))
-  })
-
   library(crul)
 
-  vcr_configure_reset()
-
   # IGNORE BY HOST
-  tmpdir <- tempdir()
-  vcr_configure(dir = tmpdir)
-  # vcr_configuration()
+  tmpdir <- withr::local_tempdir()
+  local_vcr_configure(dir = tmpdir)
   cas_not_ignored <- use_cassette("test_ignore_host", {
     HttpClient$new(hb())$get()
     HttpClient$new("https://scottchamberlain.info")$get()
   })
 
-  vcr_configure_reset()
-
-  vcr_configure(dir = tmpdir, ignore_hosts = "google.com")
-  # vcr_configuration()
+  local_vcr_configure(dir = tmpdir, ignore_hosts = "google.com")
   cas_ignored <- use_cassette("test_ignore_host_ignored", {
     HttpClient$new("https://google.com")$get()
     HttpClient$new("https://scottchamberlain.info")$get()
@@ -119,14 +103,14 @@ test_that("RequestIgnorer usage: w/ vcr_configure() usage", {
   # IGNORE LOCALHOST
   # Start python simple server on cli: python3 -m http.server
   skip_if_localhost_8000_gone()
-  tmpdir <- tempdir()
-  vcr_configure(dir = tmpdir)
+  tmpdir <- withr::local_tempdir()
+  local_vcr_configure(dir = tmpdir)
   cas_local_not_ignored <- use_cassette("test_ignore_localhost", {
     HttpClient$new("https://scottchamberlain.info")$get()
     HttpClient$new("http://127.0.0.1:8000")$get()
   })
 
-  vcr_configure(dir = tmpdir, ignore_localhost = TRUE)
+  local_vcr_configure(dir = tmpdir, ignore_localhost = TRUE)
   # vcr_configuration()
   cas_local_ignored <- use_cassette("test_ignore_localhost_ignored", {
     HttpClient$new("https://scottchamberlain.info")$get()
@@ -136,9 +120,6 @@ test_that("RequestIgnorer usage: w/ vcr_configure() usage", {
   expect_equal(length(read_cas(cas_local_not_ignored$file())), 2)
   expect_equal(length(read_cas(cas_local_ignored$file())), 1)
 })
-
-# reset
-vcr_configure(dir = tmpdir)
 
 test_that("RequestIgnorer fails well", {
   expect_error(RequestIgnorer$new(a = 5), "unused argument")

--- a/tests/testthat/test-configuration-inheritance.R
+++ b/tests/testthat/test-configuration-inheritance.R
@@ -1,5 +1,3 @@
-vcr_test_configuration()
-
 # parameters shared by config and cassettes
 # (commented params are not exposed by Cassette$cassette_opts())
 params <- c(
@@ -14,11 +12,8 @@ params <- c(
 )
 
 test_that("default cassette options match default config", {
-  on.exit({
-    unlink(vcr_files())
-  })
-
-  vcr_configure(
+  local_vcr_configure(
+    dir = withr::local_tempdir(),
     warn_on_empty_cassette = FALSE
   )
 
@@ -41,16 +36,12 @@ test_that("default cassette options match default config", {
 })
 
 test_that("cassettes inherit configured options", {
-  on.exit({
-    unlink(vcr_files())
-    vcr_test_configuration()
-  })
-
-  vcr_configure(
+  local_vcr_configure(
     record = "none",
     match_requests_on = "body",
     preserve_exact_body_bytes = TRUE,
-    warn_on_empty_cassette = FALSE
+    warn_on_empty_cassette = FALSE,
+    dir = withr::local_tempdir()
   )
 
   cas1 <- sw(use_cassette("configured-use", {
@@ -69,16 +60,12 @@ test_that("cassettes inherit configured options", {
 })
 
 test_that("cassettes can override configured options", {
-  on.exit({
-    unlink(vcr_files())
-    vcr_test_configuration()
-  })
-
-  vcr_configure(
+  local_vcr_configure(
     record = "none",
     match_requests_on = "body",
     preserve_exact_body_bytes = TRUE,
-    warn_on_empty_cassette = FALSE
+    warn_on_empty_cassette = FALSE,
+    dir = withr::local_tempdir()
   )
 
   cas1 <- sw(use_cassette(


### PR DESCRIPTION
In favour of using `local_vcr_configure()`
