### PR TITLE
Only run tests once in `R CMD check`

### DIFF
--- a/tests/test-all.R
+++ b/tests/test-all.R
@@ -1,3 +1,0 @@
-library("testthat")
-library('vcr')
-test_check("vcr")


### PR DESCRIPTION
Looks like I accidentally added this in #280, because `use_testthat()` didn't recognise the older file structure.
