### PR TITLE
Switch to `output: html_vignette()`

### DIFF
--- a/vignettes/configuration.Rmd
+++ b/vignettes/configuration.Rmd
@@ -2,11 +2,7 @@
 title: "Configure vcr"
 author: "Scott Chamberlain"
 date: "`r Sys.Date()`"
-output:
-  html_document:
-    toc: true
-    toc_float: true
-    theme: readable
+output: html_vignette
 vignette: >
   %\VignetteIndexEntry{2. vcr configuration}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/debugging.Rmd
+++ b/vignettes/debugging.Rmd
@@ -1,11 +1,7 @@
 ---
 title: "Debugging your tests that use vcr"
 date: "`r Sys.Date()`"
-output:
-  html_document:
-    toc: true
-    toc_float: true
-    theme: readable
+output: html_vignette
 vignette: >
   %\VignetteIndexEntry{4. vcr tests debugging}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/lightswitch.Rmd
+++ b/vignettes/lightswitch.Rmd
@@ -1,11 +1,7 @@
 ---
 title: "Turning vcr on and off"
 date: "`r Sys.Date()`"
-output:
-  html_document:
-    toc: true
-    toc_float: true
-    theme: readable
+output: html_vignette
 vignette: >
   %\VignetteIndexEntry{Turning vcr on and off}
   %\VignetteEngine{knitr::rmarkdown}

--- a/vignettes/record-modes.Rmd
+++ b/vignettes/record-modes.Rmd
@@ -2,11 +2,7 @@
 title: "Record modes"
 author: "Scott Chamberlain"
 date: "`r Sys.Date()`"
-output:
-  html_document:
-    toc: true
-    toc_float: true
-    theme: readable
+output: html_vignette
 vignette: >
   %\VignetteIndexEntry{vcr record modes}
   %\VignetteEngine{knitr::rmarkdown}
@@ -31,4 +27,3 @@ Request matching
 ## More documentation
 
 Check out the [http testing book](https://books.ropensci.org/http-testing/) for a lot more documentation on `vcr`, `webmockr`, and `crul`
-

--- a/vignettes/request_matching.Rmd
+++ b/vignettes/request_matching.Rmd
@@ -2,11 +2,7 @@
 title: "Configure vcr request matching"
 author: "Scott Chamberlain"
 date: "`r Sys.Date()`"
-output:
-  html_document:
-    toc: true
-    toc_float: true
-    theme: readable
+output: html_vignette
 vignette: >
   %\VignetteIndexEntry{3. request matching}
   %\VignetteEngine{knitr::rmarkdown}
@@ -31,4 +27,3 @@ Request matching
 ## More documentation
 
 Check out the [http testing book](https://books.ropensci.org/http-testing/) for a lot more documentation on `vcr`, `webmockr`, and `crul`
-

--- a/vignettes/vcr.Rmd
+++ b/vignettes/vcr.Rmd
@@ -2,11 +2,7 @@
 title: "Introduction to vcr"
 author: "Scott Chamberlain"
 date: "`r Sys.Date()`"
-output:
-  html_document:
-    toc: true
-    toc_float: true
-    theme: readable
+output: html_vignette
 vignette: >
   %\VignetteIndexEntry{1. vcr introduction}
   %\VignetteEngine{knitr::rmarkdown}
@@ -94,5 +90,3 @@ library("vcr")
 
 ```{r child='../man/rmdhunks/missing-features.Rmd', eval=TRUE} 
 ```
-
-

--- a/vignettes/write-to-disk.Rmd
+++ b/vignettes/write-to-disk.Rmd
@@ -2,11 +2,7 @@
 title: "Mocking writing to disk"
 author: "Scott Chamberlain"
 date: "`r Sys.Date()`"
-output:
-  html_document:
-    toc: true
-    toc_float: true
-    theme: readable
+output: html_vignette
 vignette: >
   %\VignetteIndexEntry{Writing to disk}
   %\VignetteEngine{knitr::rmarkdown}
@@ -35,4 +31,3 @@ library("vcr")
 ## More documentation
 
 Check out the [http testing book](https://books.ropensci.org/http-testing/) for a lot more documentation on `vcr`, `webmockr`, and `crul`
-


### PR DESCRIPTION
This makes the built package much much smaller (290 KB vs 3 MB), and gets rid of an `R CMD check` NOTE.
