### PR TITLE
Eliminate `%try%`

### DIFF
--- a/R/errors.R
+++ b/R/errors.R
@@ -215,7 +215,7 @@ UnhandledHTTPRequestError <- R6::R6Class(
         lines <- c(lines, xx)
         # FIXME: should fix this to generalize to many cassettes, see ruby code
         zz <- c(
-          paste0("  - ", self$cassette$file() %try% ""),
+          paste0("  - ", self$cassette$file()),
           paste0("    - record_mode: ", self$cassette$record),
           paste0(
             "    - match_requests_on: ",

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,11 +14,6 @@ compact <- function(x) Filter(Negate(is.null), x)
   if (missing(x) || is.null(x) || all(nchar(x) == 0) || length(x) == 0) y else x
 }
 
-`%try%` <- function(x, y) {
-  z <- tryCatch(x, error = function(e) e)
-  if (inherits(z, "error")) y else x
-}
-
 stract <- function(str, pattern) regmatches(str, regexpr(pattern, str))
 
 assert <- function(x, y) {


### PR DESCRIPTION
`casette$file()` is an accessor for `self$manfile`, so this can no longer error.
