### PR TITLE
Add an example filter to vcr_configure

### DIFF
--- a/R/configuration.R
+++ b/R/configuration.R
@@ -160,6 +160,15 @@
 #' vcr_configure(dir = tempdir(),
 #'   filter_sensitive_data = list(foo = "<bar>", hello = "<world>")
 #' )
+#' vcr_configure(
+#'  # Use regex to remove sensitive information (e.g. IP data) from cassettes
+#'  filter_sensitive_data_regex = list(
+#'    '"ip": "redacted"' = '"ip": "[0-9.]+"',
+#'    '"hostname": "redacted"' = '"hostname": "[^"]*"',
+#'    '"org": "redacted"' = '"org": "[^"]*"'
+#'  ),
+#'  dir = tempdir()
+#')
 #' @export
 
 vcr_configure <- function(...) {


### PR DESCRIPTION
## Description
This adds a simple example to the help docs that shows how to use regex to filter data, using vcr_configure. 

## Related Issue
See https://github.com/ropensci/vcr/issues/272#issuecomment-2791461513.
