### PR TITLE
More work making tests self-contained

### DIFF
--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -3,6 +3,11 @@ local_vcr_configure <- function(..., .frame = parent.frame()) {
   withr::defer(vcr_config_set(old), envir = .frame)
 }
 
+local_light_switch <- function(frame = parent.frame()) {
+  old <- as.list(light_switch)
+  withr::defer(env_bind(light_switch, !!!old), envir = frame)
+}
+
 desc_text <- "Package: %s
 Title: Does A Thing
 Description: Does a thing.

--- a/tests/testthat/test-filter_headers.R
+++ b/tests/testthat/test-filter_headers.R
@@ -64,8 +64,6 @@ test_that("filter_headers/request/remove", {
   )
 })
 
-vcr_configure_reset()
-
 test_that("filter_headers/request/replace", {
   skip_on_cran()
   local_vcr_configure(dir = withr::local_tempdir())

--- a/tests/testthat/test-filter_query_parameters.R
+++ b/tests/testthat/test-filter_query_parameters.R
@@ -1,28 +1,19 @@
-vcr_configure_reset()
-
 test_that("filter_query_parameters: fails well", {
   expect_error(vcr_configure(filter_query_parameters = list(a = 1:3)))
 })
-
-vcr_configure_reset()
-
 test_that("filter_query_parameters: remove", {
   skip_on_cran()
 
-  mydir <- file.path(tempdir(), "filter_query_parameters")
+  local_vcr_configure(dir = withr::local_tempdir())
 
   # remove only
   # no query param filtering to compare below stuff to
-  vcr_configure(dir = mydir)
   con <- crul::HttpClient$new(hb("/get"))
-  unlink(file.path(vcr_c$dir, "filterparams_no_filtering.yml"))
   cas_nofilters <- use_cassette(name = "filterparams_no_filtering", {
     res_nofilters <- con$get(query = list(Foo = "bar"))
   })
   # Do filtering
-  vcr_configure_reset()
-  vcr_configure(dir = mydir, filter_query_parameters = "Foo")
-  unlink(file.path(vcr_c$dir, "filterparams_remove.yml"))
+  local_vcr_configure(filter_query_parameters = "Foo")
   con <- crul::HttpClient$new(hb("/get"))
   cas1 <- use_cassette(name = "filterparams_remove", {
     res1 <- con$get(query = list(Foo = "bar"))
@@ -52,28 +43,21 @@ test_that("filter_query_parameters: remove", {
   )
 })
 
-vcr_configure_reset()
-
 test_that("filter_query_parameters: replace", {
   skip_on_cran()
 
-  mydir <- file.path(tempdir(), "filter_query_parameters")
+  local_vcr_configure(dir = withr::local_tempdir())
 
   # remove only
   # no query param filtering to compare below stuff to
-  vcr_configure(dir = mydir)
   con <- crul::HttpClient$new(hb("/get"))
-  unlink(file.path(vcr_c$dir, "filterparams_no_filtering.yml"))
   cas_nofilters <- use_cassette(name = "filterparams_no_filtering", {
     res_nofilters <- con$get(query = list(Foo = "bar"))
   })
   # Do filtering
-  vcr_configure_reset()
-  vcr_configure(
-    dir = mydir,
+  local_vcr_configure(
     filter_query_parameters = list(Foo = "placeholder")
   )
-  unlink(file.path(vcr_c$dir, "filterparams_replace.yml"))
   con <- crul::HttpClient$new(hb("/get"))
   cas1 <- use_cassette(name = "filterparams_replace", {
     res1 <- con$get(query = list(Foo = "bar"))
@@ -103,30 +87,23 @@ test_that("filter_query_parameters: replace", {
   )
 })
 
-vcr_configure_reset()
-
 test_that("filter_query_parameters: replace with secret", {
   skip_on_cran()
+  local_vcr_configure(dir = withr::local_tempdir())
 
   con <- crul::HttpClient$new(hb("/get"))
-  mydir <- file.path(tempdir(), "filter_query_parameters_replace_with")
-  Sys.setenv(MY_KEY = "my-secret-key")
+  withr::local_envvar(MY_KEY = "my-secret-key")
   # Sys.getenv("MY_KEY")
 
   # remove only
   # no query param filtering to compare below stuff to
-  vcr_configure(dir = mydir)
-  unlink(file.path(vcr_c$dir, "filterparams_no_filtering.yml"))
   cas_nofilters <- use_cassette(name = "filterparams_no_filtering", {
     res_nofilters <- con$get(query = list(Foo = Sys.getenv("MY_KEY")))
   })
   # Do filtering
-  vcr_configure_reset()
-  vcr_configure(
-    dir = mydir,
+  local_vcr_configure(
     filter_query_parameters = list(Foo = c(Sys.getenv("MY_KEY"), "bar"))
   )
-  unlink(file.path(vcr_c$dir, "filterparams_replacewith.yml"))
   cas1 <- use_cassette(name = "filterparams_replacewith", {
     res1 <- con$get(query = list(Foo = Sys.getenv("MY_KEY")))
   })
@@ -156,28 +133,19 @@ test_that("filter_query_parameters: replace with secret", {
     yaml::yaml.load_file(cas1$file()),
     yaml::yaml.load_file(cas2$file())
   )
-
-  Sys.unsetenv("MY_KEY")
 })
-
-vcr_configure_reset()
 
 test_that("filter_query_parameters: remove (httr)", {
   skip_on_cran()
-
-  mydir <- file.path(tempdir(), "filter_query_parameters_httr")
+  local_vcr_configure(dir = withr::local_tempdir())
 
   # remove only
   # no query param filtering to compare below stuff to
-  vcr_configure(dir = mydir)
-  unlink(file.path(vcr_c$dir, "filterparams_no_filtering.yml"))
   cas_nofilters <- use_cassette(name = "filterparams_no_filtering", {
     res_nofilters <- httr::GET(hb("/get?Foo=bar"))
   })
   # Do filtering
-  vcr_configure_reset()
-  vcr_configure(dir = mydir, filter_query_parameters = "Foo")
-  unlink(file.path(vcr_c$dir, "filterparams_remove.yml"))
+  local_vcr_configure(filter_query_parameters = "Foo")
   cas1 <- use_cassette(name = "filterparams_remove", {
     res1 <- httr::GET(hb("/get?Foo=bar"))
   })
@@ -206,27 +174,19 @@ test_that("filter_query_parameters: remove (httr)", {
   )
 })
 
-vcr_configure_reset()
-
 test_that("filter_query_parameters: replace (httr)", {
   skip_on_cran()
-
-  mydir <- file.path(tempdir(), "filter_query_parameters_httr")
+  local_vcr_configure(dir = withr::local_tempdir())
 
   # remove only
   # no query param filtering to compare below stuff to
-  vcr_configure(dir = mydir)
-  unlink(file.path(vcr_c$dir, "filterparams_no_filtering.yml"))
   cas_nofilters <- use_cassette(name = "filterparams_no_filtering", {
     res_nofilters <- httr::GET(hb("/get?Foo=bar"))
   })
   # Do filtering
-  vcr_configure_reset()
-  vcr_configure(
-    dir = mydir,
+  local_vcr_configure(
     filter_query_parameters = list(Foo = "placeholder")
   )
-  unlink(file.path(vcr_c$dir, "filterparams_replace.yml"))
   cas1 <- use_cassette(name = "filterparams_replace", {
     res1 <- httr::GET(hb("/get?Foo=bar"))
   })
@@ -254,5 +214,3 @@ test_that("filter_query_parameters: replace (httr)", {
     yaml::yaml.load_file(cas2$file())
   )
 })
-
-vcr_configure_reset()

--- a/tests/testthat/test-localhost_port.R
+++ b/tests/testthat/test-localhost_port.R
@@ -1,9 +1,8 @@
 # orginally via https://github.com/ropensci/vcr/issues/264
 
-tmpdir <- tempdir()
-vcr_configure(dir = tmpdir)
-
 test_that("testing against localhost port works", {
+  local_vcr_configure(dir = withr::local_tempdir())
+
   # httpbin <- webfakes::local_app_process(webfakes::httpbin_app())
   httpbin <- local_httpbin_app()
   url <- httpbin$url("/status/404")
@@ -21,13 +20,9 @@ test_that("testing against localhost port works", {
   })
 
   # check that the port is actually in the cassette file
-  path <- file.path(tmpdir, "localhost_port.yml")
-  file <- yaml::yaml.load_file(path)
+  file <- read_cassette("localhost_port.yml")
   url <- file$http_interactions[[1]]$request$uri
   expect_type(url, "character")
   expect_match(url, "http://.+:[0-9]+/")
   expect_match(url, as.character(port))
 })
-
-# reset configuration
-vcr_configure_reset()

--- a/tests/testthat/test-logger.R
+++ b/tests/testthat/test-logger.R
@@ -1,8 +1,3 @@
-vcr_configure(
-  log = TRUE,
-  log_opts = list(file = "vcr.log", log_prefix = "Cassette")
-)
-
 test_that("vcr_log_file fails well", {
   # must pass a file name
   expect_error(vcr_log_file(), "argument \"file\" is missing")
@@ -21,6 +16,7 @@ test_that("vcr_log_file fails well", {
 })
 
 test_that("vcr_log_file works as expected", {
+  on.exit(unlink("adsf"))
   expect_true(vcr_log_file("adsf"))
 })
 
@@ -33,6 +29,8 @@ test_that("vcr_log_file: console", {
 })
 
 test_that("vcr_log_write: console", {
+  local_vcr_configure(log = TRUE)
+
   aa <- vcr_log_file("console")
   expect_true(aa)
 
@@ -40,6 +38,7 @@ test_that("vcr_log_write: console", {
 })
 
 test_that("vcr_log_info: console", {
+  local_vcr_configure(log = TRUE)
   aa <- vcr_log_file("console")
   expect_true(aa)
 
@@ -61,10 +60,3 @@ test_that("vcr_log_info: console", {
   expect_false(grepl(as.character(format(Sys.Date(), "%Y")), log_nodate))
   expect_false(grepl("[0-9]{2}:[0-9]{2}:[0-9]{2}", log_nodate))
 })
-
-# reset configuration
-vcr_configure_reset()
-
-# cleanup
-unlink("adsf")
-unlink("vcr.log")

--- a/tests/testthat/test-vcr_last_error.R
+++ b/tests/testthat/test-vcr_last_error.R
@@ -1,35 +1,22 @@
-dir <- tempdir()
-invisible(vcr_configure(dir = dir, warn_on_empty_cassette = FALSE))
-vcr__env$last_error <- list()
-
 test_that("vcr_last_error fails well", {
+  local_vcr_configure(
+    dir = withr::local_tempdir(),
+    warn_on_empty_cassette = FALSE
+  )
+  vcr__env$last_error <- list()
+
   expect_error(vcr_last_error(), "no error to report")
 
   # insert  a cassette - same result
-  unlink(file.path(vcr_c$dir, "rabbit"))
   cas <- suppressMessages(insert_cassette("rabbit"))
-
+  on.exit(eject_cassette())
   expect_error(vcr_last_error(), "no error to report")
-
-  # cleanup before next test block
-  eject_cassette()
-  unlink(file.path(vcr_configuration()$dir, "rabbit.yml"))
 })
 
-# cleanup
-vcr_configure_reset()
-
-# setup for next block
-dir <- tempdir()
-invisible(vcr_configure(dir = dir))
-request <- Request$new(
-  "post",
-  hb("/post?a=5"),
-  "",
-  list(foo = "bar")
-)
-
 test_that("vcr_last_error works: no casssette in use yet", {
+  local_vcr_configure(dir = withr::local_tempdir())
+
+  request <- Request$new("post", hb("/post?a=5"), "", list(foo = "bar"))
   err <- UnhandledHTTPRequestError$new(request)
   expect_error(err$construct_message())
   expect_message(vcr_last_error(), "There is currently no cassette in use")
@@ -38,9 +25,10 @@ test_that("vcr_last_error works: no casssette in use yet", {
 })
 
 test_that("vcr_last_error works: casssette in use", {
-  unlink(file.path(vcr_c$dir, "bunny"))
-  cas <- suppressMessages(insert_cassette("bunny"))
+  local_vcr_configure(dir = withr::local_tempdir())
+  request <- Request$new("post", hb("/post?a=5"), "", list(foo = "bar"))
 
+  cas <- insert_cassette("bunny")
   err <- UnhandledHTTPRequestError$new(request)
   expect_error(err$construct_message())
   expect_message(
@@ -50,8 +38,3 @@ test_that("vcr_last_error works: casssette in use", {
   expect_message(vcr_last_error(), "Under the current configuration")
   expect_message(vcr_last_error(), "new_episodes")
 })
-
-# reset configuration
-suppressWarnings(eject_cassette())
-unlink(file.path(vcr_configuration()$dir, "bunny.yml"))
-vcr_configure_reset()


### PR DESCRIPTION
Introduced new helper to ensure that changes to `light_switch` state are kept local to the test.
