### PR TITLE
Use `format()` instead of `as.character()`

### DIFF
--- a/R/logger.R
+++ b/R/logger.R
@@ -71,7 +71,11 @@ vcr_log_file <- function(file, overwrite = TRUE) {
 #' @export
 #' @rdname vcr_logging
 vcr_log_info <- function(message, include_date = TRUE) {
-  if (include_date) message <- paste(as.character(Sys.time()), "-", message)
+  if (include_date) {
+    now <- format(Sys.time(), format = "%Y-%m-%d %H:%M:%S")
+    message <- paste(now, "-", message)
+  }
+
   message <- paste(make_prefix(), "-", message)
   vcr_log_write(message)
 }


### PR DESCRIPTION
This ensures that the timestamp always has the same number of characters, nicely aligning the log lines. Otherwise (e.g.) `as.character(as.POSIXct("2002-1-1"))` gives `2002-01-01`.
