### PR TITLE
Polish `Cassette$eject()`

### DIFF
--- a/R/eject_cassette.R
+++ b/R/eject_cassette.R
@@ -15,8 +15,10 @@ eject_cassette <- function() {
   }
 
   cassette <- cassette_pop()
+  if (!vcr_c$quiet) message("ejecting cassette: ", cassette$name)
   cassette$eject()
 
+  webmockr::disable(quiet = vcr_c$quiet)
   if (!cassette_active()) {
     suppressMessages(webmockr::webmockr_disable_net_connect())
   }

--- a/tests/testthat/_snaps/cassette_class.md
+++ b/tests/testthat/_snaps/cassette_class.md
@@ -32,10 +32,10 @@
       . <- cl$eject()
     Condition
       Warning:
-      Empty cassette (test) deleted; consider the following:
-       - If an error occurred resolve that first, then check:
-       - vcr only supports crul, httr & httr2; requests w/ curl, download.file, etc. are not supported
-       - If you are using crul/httr/httr2, are you sure you made an HTTP request?
+      x "test" cassette ejected without recording any interactions.
+      i Did your request error?
+      i Did you use {curl}, `download.file()`, or other unsupported tool?
+      i If you are using crul/httr/httr2, are you sure you made an HTTP request?
 
 # cassette checks name
 


### PR DESCRIPTION
* Move messaging to `eject_casette()`
* Put all code related to warning in one place
* Convert warning to use cli
