### PR TITLE
WIP: drop strip port skipping

### DIFF
--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -572,8 +572,7 @@ Cassette <- R6::R6Class(
           x$request_headers
         },
         opts = self$cassette_opts,
-        disk = is_disk,
-        skip_port_stripping = TRUE
+        disk = is_disk
       )
 
       response <- VcrResponse$new(

--- a/R/request_class.R
+++ b/R/request_class.R
@@ -39,8 +39,6 @@ Request <- R6::R6Class(
     body = NULL,
     #' @field headers (character) named list
     headers = NULL,
-    #' @field skip_port_stripping (logical) whether to strip the port
-    skip_port_stripping = FALSE,
     #' @field hash (character) a named list - internal use
     hash = NULL,
     #' @field opts (character) options - internal use
@@ -65,7 +63,6 @@ Request <- R6::R6Class(
     #' @param fields (various) post fields
     #' @param output (various) output details
     #' @param policies (various) http policies, used in httr2 only
-    #' @param skip_port_stripping (logical) whether to strip the port.
     #' default: `FALSE`
     #' @return A new `Request` object
     initialize = function(
@@ -77,8 +74,7 @@ Request <- R6::R6Class(
       disk,
       fields,
       output,
-      policies,
-      skip_port_stripping = FALSE
+      policies
     ) {
       if (!missing(method)) self$method <- tolower(method)
       if (!missing(body)) {
@@ -89,11 +85,7 @@ Request <- R6::R6Class(
       }
       if (!missing(headers)) self$headers <- headers
       if (!missing(uri)) {
-        if (!skip_port_stripping) {
-          self$uri <- private$without_standard_port(uri)
-        } else {
-          self$uri <- uri
-        }
+        self$uri <- uri
         # parse URI to get host and path
         tmp <- eval(parse(text = vcr_c$uri_parser))(self$uri)
         self$scheme <- tmp$scheme

--- a/R/request_class.R
+++ b/R/request_class.R
@@ -128,24 +128,6 @@ Request <- R6::R6Class(
         disk = hash[['disk']]
       )
     }
-  ),
-  private = list(
-    without_standard_port = function(uri) {
-      if (is.null(uri)) return(uri)
-      u <- private$parsed_uri(uri)
-      if (
-        paste0(u$scheme, if (is.na(u$port)) NULL else u$port) %in%
-          c('http', 'https/443')
-      ) {
-        return(uri)
-      }
-      u$port <- NA
-      return(urltools::url_compose(u))
-    },
-
-    parsed_uri = function(uri) {
-      urltools::url_parse(uri)
-    }
   )
 )
 

--- a/man/Request.Rd
+++ b/man/Request.Rd
@@ -45,8 +45,6 @@ x$from_hash(h)
 
 \item{\code{headers}}{(character) named list}
 
-\item{\code{skip_port_stripping}}{(logical) whether to strip the port}
-
 \item{\code{hash}}{(character) a named list - internal use}
 
 \item{\code{opts}}{(character) options - internal use}
@@ -76,18 +74,7 @@ x$from_hash(h)
 \subsection{Method \code{new()}}{
 Create a new \code{Request} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Request$new(
-  method,
-  uri,
-  body,
-  headers,
-  opts,
-  disk,
-  fields,
-  output,
-  policies,
-  skip_port_stripping = FALSE
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Request$new(method, uri, body, headers, opts, disk, fields, output, policies)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -110,9 +97,7 @@ post, put, patch or delete)}
 
 \item{\code{output}}{(various) output details}
 
-\item{\code{policies}}{(various) http policies, used in httr2 only}
-
-\item{\code{skip_port_stripping}}{(logical) whether to strip the port.
+\item{\code{policies}}{(various) http policies, used in httr2 only
 default: \code{FALSE}}
 }
 \if{html}{\out{</div>}}

--- a/tests/testthat/test-Request.R
+++ b/tests/testthat/test-Request.R
@@ -13,7 +13,6 @@ test_that("Request basic stuff", {
   expect_null(aa$query)
   expect_null(aa$scheme)
   expect_null(aa$uri)
-  expect_false(aa$skip_port_stripping)
 
   # methods
   expect_type(aa$from_hash, "closure")
@@ -21,7 +20,7 @@ test_that("Request basic stuff", {
 })
 
 test_that("Request usage", {
-  url <- hb("/post")
+  url <- "http://127.0.0.1/post"
   body <- list(foo = "bar")
   headers <- list(
     `User-Agent` = "libcurl/7.54.0 r-curl/3.2 crul/0.5.2",

--- a/tests/testthat/test-request_summary.R
+++ b/tests/testthat/test-request_summary.R
@@ -21,8 +21,8 @@ test_that("request_summary works", {
   expect_type(cc, "character")
   expect_type(dd, "character")
 
-  expect_match(aa, "post .+/")
-  expect_match(bb, "post .+/ foo=bar")
+  expect_match(aa, "post .+")
+  expect_match(bb, "post .+ foo=bar")
 
   expect_match(cc, "post")
   expect_match(cc, ".+")


### PR DESCRIPTION
Waiting on #333 to change the uri matcher to ignore the port, and add a new uri_with_port option.
