### PR TITLE
Sanitize uri during `prep_interaction()`

### DIFF
--- a/R/request_matcher_registry.R
+++ b/R/request_matcher_registry.R
@@ -53,7 +53,7 @@ RequestMatcherRegistry <- R6::R6Class(
         "uri",
         function(r1, r2)
           identical(
-            curl::curl_unescape(query_params_remove_str(r1$uri)),
+            curl::curl_unescape(query_params_remove(r1$uri, flip = TRUE)),
             curl::curl_unescape(r2$uri)
           )
       )

--- a/R/write.R
+++ b/R/write.R
@@ -55,7 +55,7 @@ prep_interaction <- function(x, file, bytes) {
     list(
       request = list(
         method = x$request$method,
-        uri = x$request$uri,
+        uri = query_params_remove(x$request$uri),
         body = list(
           encoding = "",
           string = get_body(x$request$body)
@@ -89,7 +89,6 @@ write_interactions <- function(x, file, bytes) {
   z <- prep_interaction(x, file, bytes)
   z <- headers_remove(z)
   z <- request_headers_redact(z)
-  z <- query_params_remove(z)
   tmp <- yaml::as.yaml(z)
   tmp <- sensitive_remove(tmp)
   cat(tmp, file = file, append = TRUE)
@@ -100,7 +99,6 @@ write_interactions_json <- function(x, file, bytes) {
   z <- headers_remove(z)
   z <- request_headers_redact(z)
   z <- headers_unclass(z)
-  z <- query_params_remove(z)
   # combine with existing data on same file, if any
   on_disk <- invisible(tryCatch(
     jsonlite::fromJSON(file, FALSE),


### PR DESCRIPTION
This is the first PR in a series of PRs that moves logic out of `write_interactions()` and into `prep_interactions()`. This should also make the code a little faster since eventually we'll only need to loop through the list of interactions once.
