### PR TITLE
Update eject logging

### DIFF
--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -253,8 +253,6 @@ Cassette <- R6::R6Class(
     #' @description ejects the cassette
     #' @return self
     eject = function() {
-      vcr_log_info("Ejecting casette", vcr_c$log_opts$date)
-
       self$write_recorded_interactions_to_disk()
 
       if (self$is_empty()) {

--- a/R/eject_cassette.R
+++ b/R/eject_cassette.R
@@ -14,7 +14,7 @@ eject_cassette <- function() {
     cli::cli_abort("No cassette in use")
   }
 
-  vcr_log_sprintf("Ejecting casette")
+  vcr_log_sprintf("Ejecting")
   cassette <- cassette_pop()
   cassette$eject()
 

--- a/R/eject_cassette.R
+++ b/R/eject_cassette.R
@@ -14,6 +14,7 @@ eject_cassette <- function() {
     cli::cli_abort("No cassette in use")
   }
 
+  vcr_log_sprintf("Ejecting casette")
   cassette <- cassette_pop()
   cassette$eject()
 

--- a/R/insert_cassette.R
+++ b/R/insert_cassette.R
@@ -47,6 +47,7 @@ insert_cassette <- function(
     clean_outdated_http_interactions = clean_outdated_http_interactions
   )
   cassette_push(cassette)
+  vcr_log_sprintf("Inserting")
   cassette$insert()
 
   invisible(cassette)

--- a/tests/testthat/_snaps/insert_cassette.md
+++ b/tests/testthat/_snaps/insert_cassette.md
@@ -1,0 +1,16 @@
+# inserting and ejecting is logged
+
+    Code
+      . <- use_cassette("test", NULL)
+    Output
+      [Cassette: "test"] - Inserting
+      [Cassette: "test"] - Init. HTTPInteractionList w/ request matchers [method, uri] & 0 interaction(s): {  }
+      [Cassette: "test"] - Initialized with options: {name: test, record: once, serialize_with: yaml, match_requests_on: c("method", "uri"), allow_playback_repeats: FALSE, preserve_exact_body_bytes: FALSE}
+      [Cassette: "test"] - Ejecting
+    Condition
+      Warning:
+      x "test" cassette ejected without recording any interactions.
+      i Did your request error?
+      i Did you use {curl}, `download.file()`, or other unsupported tool?
+      i If you are using crul/httr/httr2, are you sure you made an HTTP request?
+

--- a/tests/testthat/_snaps/insert_cassette.md
+++ b/tests/testthat/_snaps/insert_cassette.md
@@ -7,10 +7,4 @@
       [Cassette: "test"] - Init. HTTPInteractionList w/ request matchers [method, uri] & 0 interaction(s): {  }
       [Cassette: "test"] - Initialized with options: {name: test, record: once, serialize_with: yaml, match_requests_on: c("method", "uri"), allow_playback_repeats: FALSE, preserve_exact_body_bytes: FALSE}
       [Cassette: "test"] - Ejecting
-    Condition
-      Warning:
-      x "test" cassette ejected without recording any interactions.
-      i Did your request error?
-      i Did you use {curl}, `download.file()`, or other unsupported tool?
-      i If you are using crul/httr/httr2, are you sure you made an HTTP request?
 

--- a/tests/testthat/test-insert_cassette.R
+++ b/tests/testthat/test-insert_cassette.R
@@ -14,6 +14,7 @@ test_that("insert_cassette works as expected", {
 })
 
 test_that("inserting and ejecting is logged", {
+  local_vcr_configure(warn_on_empty_cassette = FALSE)
   local_vcr_configure_log(file = stdout())
 
   expect_snapshot(. <- use_cassette("test", NULL))

--- a/tests/testthat/test-insert_cassette.R
+++ b/tests/testthat/test-insert_cassette.R
@@ -12,3 +12,9 @@ test_that("insert_cassette works as expected", {
   expect_false(aa$allow_playback_repeats)
   expect_false(aa$any_new_recorded_interactions())
 })
+
+test_that("inserting and ejecting is logged", {
+  local_vcr_configure_log(file = stdout())
+
+  expect_snapshot(. <- use_cassette("test", NULL))
+})


### PR DESCRIPTION
@sckott I think this was a non-obvious merge conflict. I added a test to make sure it doesn't happen again, and also added a parallel insert log entry.