### PR TITLE
Drop `allow_http_connections_when_no_cassette` option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ vcr (development version)
 
 ### BREAKING CHANGES
 
+* `vcr_configureation(allow_http_connections_when_no_cassette)` is no longer supported. It hasn't worked for a while.
 * `vcr_configuration(quiet = FALSE)` is no longer supported. If you need more information about what's happening, turn on logging.
 * `str_splitter()` has been removed; it was accidentally exported as it's not part of the core vcrs API.
 * `cassettes()` are now a stack. The most important consequence of this is that `eject_cassette()` can only remove the most recently inserted cassette.

--- a/R/configuration.R
+++ b/R/configuration.R
@@ -29,11 +29,6 @@
 #' - `turned_off` (logical) VCR is turned on by default. Default:
 #' `FALSE`
 #' - `allow_unused_http_interactions` (logical) Default: `TRUE`
-#' - `allow_http_connections_when_no_cassette` (logical) Determines how vcr
-#' treats HTTP requests that are made when no vcr cassette is in use. When
-#' `TRUE`, requests made when there is no vcr cassette in use will be allowed.
-#' When `FALSE` (default), an [UnhandledHTTPRequestError] error will be raised
-#' for any HTTP request made when there is no cassette in use
 #'
 #' ### Filtering
 #'
@@ -207,7 +202,6 @@ VCRConfig <- R6::R6Class(
     .turned_off = NULL,
     .re_record_interval = NULL,
     .clean_outdated_http_interactions = NULL,
-    .allow_http_connections_when_no_cassette = NULL,
     .cassettes = NULL,
     .linked_context = NULL,
     .log = NULL,
@@ -278,11 +272,6 @@ VCRConfig <- R6::R6Class(
     clean_outdated_http_interactions = function(value) {
       if (missing(value)) return(private$.clean_outdated_http_interactions)
       private$.clean_outdated_http_interactions <- value
-    },
-    allow_http_connections_when_no_cassette = function(value) {
-      if (missing(value))
-        return(private$.allow_http_connections_when_no_cassette)
-      private$.allow_http_connections_when_no_cassette <- value
     },
     cassettes = function(value) {
       if (missing(value)) return(private$.cassettes)
@@ -362,7 +351,6 @@ VCRConfig <- R6::R6Class(
       turned_off = FALSE,
       re_record_interval = NULL,
       clean_outdated_http_interactions = FALSE,
-      allow_http_connections_when_no_cassette = FALSE,
       cassettes = list(),
       linked_context = NULL,
       log = FALSE,
@@ -390,7 +378,6 @@ VCRConfig <- R6::R6Class(
       self$turned_off <- turned_off
       self$re_record_interval <- re_record_interval
       self$clean_outdated_http_interactions <- clean_outdated_http_interactions
-      self$allow_http_connections_when_no_cassette <- allow_http_connections_when_no_cassette
       self$cassettes <- cassettes
       self$linked_context <- linked_context
       self$log <- log

--- a/R/error_suggestions.R
+++ b/R/error_suggestions.R
@@ -34,15 +34,6 @@ error_suggestions <- list(
     url = "https://books.ropensci.org/http-testing/intro"
   ),
 
-  allow_http_connections_when_no_cassette = list(
-    text = c(
-      "If you only want vcr to handle requests made while a cassette is in use,",
-      "configure `allow_http_connections_when_no_cassette = TRUE`. vcr will",
-      "ignore this request since it is made when there is no cassette"
-    ),
-    url = "https://books.ropensci.org/http-testing/vcr-configuration#allow-http-connections-when-no-cassette"
-  ),
-
   ignore_request = list(
     text = c(
       "If you want vcr to ignore this request (and others like it), you can",

--- a/R/errors.R
+++ b/R/errors.R
@@ -316,7 +316,6 @@ UnhandledHTTPRequestError <- R6::R6Class(
       x <- c(
         "try_debug_logger",
         "use_a_cassette",
-        "allow_http_connections_when_no_cassette",
         "ignore_request"
       )
       lapply(x, self$suggestion_for)

--- a/R/real_connections.R
+++ b/R/real_connections.R
@@ -5,9 +5,9 @@
 #' @examples
 #' real_http_connections_allowed()
 real_http_connections_allowed <- function() {
-  trycurr <- tryCatch(current_cassette(), error = function(e) e)
-  if (!inherits(trycurr, "error") && !is.null(trycurr))
-    return(current_cassette()$recording())
-  if (is.null(trycurr)) return(FALSE)
-  !(vcr_c$allow_http_connections_when_no_cassette || !turned_on())
+  if (cassette_active()) {
+    current_cassette()$recording()
+  } else {
+    FALSE
+  }
 }


### PR DESCRIPTION
This hasn't worked since `current_cassette()` returned an empty object rather than erroring, so I think it's probably just as easy to remove
