### PR TITLE
Remove unused `ResponseHandler` fields/methods

### DIFF
--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -253,7 +253,7 @@ Cassette <- R6::R6Class(
     #' @description ejects the cassette
     #' @return self
     eject = function() {
-      vcr_log_info("Ejecting casette", vcr_c$log_opts$date)
+      # vcr_log_info("Ejecting casette", vcr_c$log_opts$date)
 
       self$write_recorded_interactions_to_disk()
 

--- a/R/request_handler-httr.R
+++ b/R/request_handler-httr.R
@@ -53,26 +53,14 @@ RequestHandlerHttr <- R6::R6Class(
           output = request$output
         )
       }
-      self$cassette <- tryCatch(current_cassette(), error = function(e) e)
     }
   ),
 
   private = list(
-    # make a `vcr` response
-    response_for = function(x) {
-      VcrResponse$new(
-        c(list(status_code = x$status_code), httr::http_status(x)),
-        x$headers,
-        httr::content(x, encoding = "UTF-8"),
-        x$all_headers[[1]]$version
-      )
-    },
-
     # these will replace those in
     on_ignored_request = function(request) {
       # perform and return REAL http response
       # * make real request
-      # * run through response_for() to make vcr response, store vcr response
       # * give back real response
 
       # real request
@@ -84,9 +72,6 @@ RequestHandlerHttr <- R6::R6Class(
         do.call(httr::config, request$options),
         httr::add_headers(request$headers)
       )
-
-      # run through response_for()
-      self$vcr_response <- private$response_for(tmp2)
 
       # return real response
       return(response)
@@ -117,10 +102,10 @@ RequestHandlerHttr <- R6::R6Class(
       response <- webmockr::build_httr_response(self$request_original, tmp2)
 
       # make vcr response | then record interaction
-      self$vcr_response <- private$response_for(response)
-      cas <- tryCatch(current_cassette(), error = function(e) e)
-      if (inherits(cas, "error")) stop("no cassette in use")
-      cas$record_http_interaction(response)
+      if (!cassette_active()) {
+        cli::cli_abort("No cassette in use.")
+      }
+      current_cassette()$record_http_interaction(response)
 
       # return real response
       return(response)

--- a/R/request_handler-httr2.R
+++ b/R/request_handler-httr2.R
@@ -50,38 +50,20 @@ RequestHandlerHttr2 <- R6::R6Class(
           policies = request$policies
         )
       }
-      self$cassette <- tryCatch(current_cassette(), error = function(e) e)
     }
   ),
 
   private = list(
-    # make a `vcr` response
-    response_for = function(x) {
-      VcrResponse$new(
-        list(
-          status_code = x$status_code,
-          description = httr2::resp_status_desc(x)
-        ),
-        x$headers,
-        x$body,
-        ""
-      )
-    },
-
     # these will replace those in
     on_ignored_request = function(request) {
       # perform and return REAL http response
       # * make real request
-      # * run through response_for() to make vcr response, store vcr response
       # * give back real response
 
       # real request
       webmockr::httr2_mock(FALSE)
       on.exit(webmockr::httr2_mock(TRUE), add = TRUE)
-      tmp2 <- httr2::req_perform(request)
-
-      # run through response_for()
-      self$vcr_response <- private$response_for(tmp2)
+      response <- httr2::req_perform(request)
 
       # return real response
       return(response)
@@ -110,13 +92,12 @@ RequestHandlerHttr2 <- R6::R6Class(
 
       response <- webmockr::build_httr2_response(self$request_original, tmp2)
 
-      # make vcr response | then record interaction
-      self$vcr_response <- private$response_for(response)
-      cas <- tryCatch(current_cassette(), error = function(e) e)
-      if (inherits(cas, "error")) stop("no cassette in use")
+      if (!cassette_active()) {
+        cli::cli_abort("No cassette in use.")
+      }
       response$request <- self$request_original
       response$request$method <- webmockr:::req_method_get_w(response$request)
-      cas$record_http_interaction(response)
+      current_cassette()$record_http_interaction(response)
 
       # return real response
       # print("------- before return -------")

--- a/R/request_handler.R
+++ b/R/request_handler.R
@@ -76,12 +76,8 @@ RequestHandler <- R6::R6Class(
     request_original = NULL,
     #' @field request the request, after any modification
     request = NULL,
-    #' @field vcr_response holds [VcrResponse] object
-    vcr_response = NULL,
     #' @field stubbed_response the stubbed response
     stubbed_response = NULL,
-    #' @field cassette the cassette holder
-    cassette = NULL,
 
     #' @description Create a new `RequestHandler` object
     #' @param request The request from an object of class `HttpInteraction`
@@ -97,7 +93,6 @@ RequestHandler <- R6::R6Class(
           disk = !is.null(request$output$path)
         )
       }
-      self$cassette <- tryCatch(current_cassette(), error = function(e) e)
     },
 
     #' @description Handle the request (`request` given in `$initialize()`)
@@ -124,14 +119,7 @@ RequestHandler <- R6::R6Class(
 
   private = list(
     request_summary = function(request) {
-      request_matchers <- if (
-        !inherits(self$cassette, "error") &&
-          !is.null(self$cassette)
-      ) {
-        self$cassette$match_requests_on
-      } else {
-        vcr_c$match_requests_on
-      }
+      request_matches <- current_casssette()$match_requests_on
       request_summary(Request$new()$from_hash(request), request_matchers)
     },
 

--- a/man/RequestHandler.Rd
+++ b/man/RequestHandler.Rd
@@ -84,11 +84,7 @@ eject_cassette()
 
 \item{\code{request}}{the request, after any modification}
 
-\item{\code{vcr_response}}{holds \link{VcrResponse} object}
-
 \item{\code{stubbed_response}}{the stubbed response}
-
-\item{\code{cassette}}{the cassette holder}
 }
 \if{html}{\out{</div>}}
 }


### PR DESCRIPTION
`$cassette` and `$vcr_response` were set, but never read. `$reponse_for()` was only used to set `$vcr_response` so can now be removed.
