### PR TITLE
Drop `cassette_opts`

### DIFF
--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -81,8 +81,6 @@ Cassette <- R6::R6Class(
     clean_outdated_http_interactions = FALSE,
     #' @field to_return (logical) internal use
     to_return = NULL,
-    #' @field cassette_opts (list) various cassette options
-    cassette_opts = NULL,
 
     #' @description Create a new `Cassette` object
     #' @param dir The directory where the cassette will be stored.
@@ -225,7 +223,7 @@ Cassette <- R6::R6Class(
         invisible(lapply(prev, stub_previous_request))
       }
 
-      self$cassette_opts <- compact(list(
+      opts <- compact(list(
         name = self$name,
         record = self$record,
         serialize_with = self$serialize_with,
@@ -233,12 +231,7 @@ Cassette <- R6::R6Class(
         allow_playback_repeats = self$allow_playback_repeats,
         preserve_exact_body_bytes = self$preserve_exact_body_bytes
       ))
-      init_opts <- paste(
-        names(self$cassette_opts),
-        unname(self$cassette_opts),
-        sep = ": ",
-        collapse = ", "
-      )
+      init_opts <- paste(names(opts), unname(opts), sep = ": ", collapse = ", ")
       vcr_log_sprintf("Initialized with options: {%s}", init_opts)
 
       # create new env for recorded interactions
@@ -520,7 +513,6 @@ Cassette <- R6::R6Class(
         } else {
           x$request_headers
         },
-        opts = self$cassette_opts,
         disk = is_disk,
         skip_port_stripping = TRUE
       )

--- a/R/request_class.R
+++ b/R/request_class.R
@@ -43,8 +43,6 @@ Request <- R6::R6Class(
     skip_port_stripping = FALSE,
     #' @field hash (character) a named list - internal use
     hash = NULL,
-    #' @field opts (character) options - internal use
-    opts = NULL,
     #' @field disk (logical) xx
     disk = NULL,
     #' @field fields (various) request body details
@@ -60,7 +58,6 @@ Request <- R6::R6Class(
     #' @param uri (character) request URI
     #' @param body (character) request body
     #' @param headers (named list) request headers
-    #' @param opts (named list) options internal use
     #' @param disk (boolean), is body a file on disk
     #' @param fields (various) post fields
     #' @param output (various) output details
@@ -73,7 +70,6 @@ Request <- R6::R6Class(
       uri,
       body,
       headers,
-      opts,
       disk,
       fields,
       output,
@@ -101,7 +97,6 @@ Request <- R6::R6Class(
         self$path <- tmp$path
         self$query <- tmp$parameter
       }
-      if (!missing(opts)) self$opts <- opts
       if (!missing(disk)) self$disk <- disk
       if (!missing(fields)) self$fields <- fields
       if (!missing(output)) self$output <- output

--- a/R/request_handler-httr2.R
+++ b/R/request_handler-httr2.R
@@ -39,14 +39,10 @@ RequestHandlerHttr2 <- R6::R6Class(
       self$request <- {
         Request$new(
           request$method,
-
           request$url,
           take_body(request),
-
           request$headers,
           fields = request$fields,
-
-          opts = request$options,
           policies = request$policies
         )
       }

--- a/man/Cassette.Rd
+++ b/man/Cassette.Rd
@@ -96,8 +96,6 @@ bytes of the requests and responses}
 be recorded back to file}
 
 \item{\code{to_return}}{(logical) internal use}
-
-\item{\code{cassette_opts}}{(list) various cassette options}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Request.Rd
+++ b/man/Request.Rd
@@ -49,8 +49,6 @@ x$from_hash(h)
 
 \item{\code{hash}}{(character) a named list - internal use}
 
-\item{\code{opts}}{(character) options - internal use}
-
 \item{\code{disk}}{(logical) xx}
 
 \item{\code{fields}}{(various) request body details}
@@ -81,7 +79,6 @@ Create a new \code{Request} object
   uri,
   body,
   headers,
-  opts,
   disk,
   fields,
   output,
@@ -101,8 +98,6 @@ post, put, patch or delete)}
 \item{\code{body}}{(character) request body}
 
 \item{\code{headers}}{(named list) request headers}
-
-\item{\code{opts}}{(named list) options internal use}
 
 \item{\code{disk}}{(boolean), is body a file on disk}
 

--- a/man/vcr_configure.Rd
+++ b/man/vcr_configure.Rd
@@ -55,11 +55,6 @@ you'll likely have to skip the associated tests as well).
 \item \code{turned_off} (logical) VCR is turned on by default. Default:
 \code{FALSE}
 \item \code{allow_unused_http_interactions} (logical) Default: \code{TRUE}
-\item \code{allow_http_connections_when_no_cassette} (logical) Determines how vcr
-treats HTTP requests that are made when no vcr cassette is in use. When
-\code{TRUE}, requests made when there is no vcr cassette in use will be allowed.
-When \code{FALSE} (default), an \link{UnhandledHTTPRequestError} error will be raised
-for any HTTP request made when there is no cassette in use
 }
 }
 


### PR DESCRIPTION
They're now only used for logging so no need to store
