### PR TITLE
Add `warn_on_empty` field to cassette

### DIFF
--- a/R/cassettes.R
+++ b/R/cassettes.R
@@ -25,7 +25,8 @@ insert_cassette <- function(
   serialize_with = NULL,
   preserve_exact_body_bytes = NULL,
   re_record_interval = NULL,
-  clean_outdated_http_interactions = NULL
+  clean_outdated_http_interactions = NULL,
+  warn_on_empty = NULL
 ) {
   if (!turned_on()) {
     if (!the$light_switch$ignore_cassettes) {
@@ -53,7 +54,8 @@ insert_cassette <- function(
     serialize_with = serialize_with,
     preserve_exact_body_bytes = preserve_exact_body_bytes,
     re_record_interval = re_record_interval,
-    clean_outdated_http_interactions = clean_outdated_http_interactions
+    clean_outdated_http_interactions = clean_outdated_http_interactions,
+    warn_on_empty = warn_on_empty
   )
   cassette_push(cassette)
   vcr_log_sprintf("Inserting")

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -44,6 +44,8 @@
 #' cassette should be re-recorded. default: `NULL` (not re-recorded)
 #' @param clean_outdated_http_interactions (logical) Should outdated
 #' interactions be recorded back to file? default: `FALSE`
+#' @param warn_on_empty Warn if the cassette is ejected but no interactions
+#'   have been recorded?
 #' @seealso [insert_cassette()] and [eject_cassette()] for the underlying
 #'   functions.
 #' @section Cassette options:
@@ -156,7 +158,8 @@ use_cassette <- function(
   serialize_with = NULL,
   preserve_exact_body_bytes = NULL,
   re_record_interval = NULL,
-  clean_outdated_http_interactions = NULL
+  clean_outdated_http_interactions = NULL,
+  warn_on_empty = NULL
 ) {
   check_required(name)
   if (missing(...)) {
@@ -175,7 +178,8 @@ use_cassette <- function(
     serialize_with = serialize_with,
     preserve_exact_body_bytes = preserve_exact_body_bytes,
     re_record_interval = re_record_interval,
-    clean_outdated_http_interactions = clean_outdated_http_interactions
+    clean_outdated_http_interactions = clean_outdated_http_interactions,
+    warn_on_empty = warn_on_empty
   )
 
   # force all arguments
@@ -200,6 +204,7 @@ local_cassette <- function(
   preserve_exact_body_bytes = NULL,
   re_record_interval = NULL,
   clean_outdated_http_interactions = NULL,
+  warn_on_empty = NULL,
   frame = parent.frame()
 ) {
   cassette <- insert_cassette(
@@ -211,7 +216,8 @@ local_cassette <- function(
     serialize_with = serialize_with,
     preserve_exact_body_bytes = preserve_exact_body_bytes,
     re_record_interval = re_record_interval,
-    clean_outdated_http_interactions = clean_outdated_http_interactions
+    clean_outdated_http_interactions = clean_outdated_http_interactions,
+    warn_on_empty = warn_on_empty
   )
   if (!is.null(cassette)) {
     withr::defer(eject_cassette(), envir = frame)

--- a/man/Cassette.Rd
+++ b/man/Cassette.Rd
@@ -98,6 +98,8 @@ be recorded back to file}
 \item{\code{to_return}}{(logical) internal use}
 
 \item{\code{cassette_opts}}{(list) various cassette options}
+
+\item{\code{warn_on_empty}}{(logical) warn if no interactions recorded}
 }
 \if{html}{\out{</div>}}
 }
@@ -140,7 +142,8 @@ Create a new \code{Cassette} object
   serialize_with = NULL,
   preserve_exact_body_bytes = NULL,
   re_record_interval = NULL,
-  clean_outdated_http_interactions = NULL
+  clean_outdated_http_interactions = NULL,
+  warn_on_empty = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -178,6 +181,9 @@ re-recorded at the given interval, in seconds.}
 
 \item{\code{clean_outdated_http_interactions}}{(logical) Should outdated interactions
 be recorded back to file. Default: \code{FALSE}}
+
+\item{\code{warn_on_empty}}{Warn when ejecting the cassette if no interactions
+have been recorded.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/insert_cassette.Rd
+++ b/man/insert_cassette.Rd
@@ -14,7 +14,8 @@ insert_cassette(
   serialize_with = NULL,
   preserve_exact_body_bytes = NULL,
   re_record_interval = NULL,
-  clean_outdated_http_interactions = NULL
+  clean_outdated_http_interactions = NULL,
+  warn_on_empty = NULL
 )
 
 eject_cassette()
@@ -64,6 +65,9 @@ cassette should be re-recorded. default: \code{NULL} (not re-recorded)}
 
 \item{clean_outdated_http_interactions}{(logical) Should outdated
 interactions be recorded back to file? default: \code{FALSE}}
+
+\item{warn_on_empty}{Warn if the cassette is ejected but no interactions
+have been recorded?}
 }
 \value{
 A \link{Cassette}, invisibly.

--- a/man/use_cassette.Rd
+++ b/man/use_cassette.Rd
@@ -15,7 +15,8 @@ use_cassette(
   serialize_with = NULL,
   preserve_exact_body_bytes = NULL,
   re_record_interval = NULL,
-  clean_outdated_http_interactions = NULL
+  clean_outdated_http_interactions = NULL,
+  warn_on_empty = NULL
 )
 
 local_cassette(
@@ -28,6 +29,7 @@ local_cassette(
   preserve_exact_body_bytes = NULL,
   re_record_interval = NULL,
   clean_outdated_http_interactions = NULL,
+  warn_on_empty = NULL,
   frame = parent.frame()
 )
 }
@@ -80,6 +82,9 @@ cassette should be re-recorded. default: \code{NULL} (not re-recorded)}
 
 \item{clean_outdated_http_interactions}{(logical) Should outdated
 interactions be recorded back to file? default: \code{FALSE}}
+
+\item{warn_on_empty}{Warn if the cassette is ejected but no interactions
+have been recorded?}
 
 \item{frame}{Attach exit handlers to this environment. Typically, this
 should be either the current environment or a parent frame (accessed

--- a/man/vcr_configure.Rd
+++ b/man/vcr_configure.Rd
@@ -55,11 +55,6 @@ you'll likely have to skip the associated tests as well).
 \item \code{turned_off} (logical) VCR is turned on by default. Default:
 \code{FALSE}
 \item \code{allow_unused_http_interactions} (logical) Default: \code{TRUE}
-\item \code{allow_http_connections_when_no_cassette} (logical) Determines how vcr
-treats HTTP requests that are made when no vcr cassette is in use. When
-\code{TRUE}, requests made when there is no vcr cassette in use will be allowed.
-When \code{FALSE} (default), an \link{UnhandledHTTPRequestError} error will be raised
-for any HTTP request made when there is no cassette in use
 }
 }
 

--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -108,6 +108,7 @@ testthat::set_state_inspector(\() {
 
   list(
     temp_files = temp_files,
+    wd_files = dir(),
     vcr_config = vcr_c$as_list()
   )
 })

--- a/tests/testthat/test-RequestHandler.R
+++ b/tests/testthat/test-RequestHandler.R
@@ -22,12 +22,10 @@ test_that("RequestHandlerHttr: httr", {
   expect_error(x$handle())
 
   # do request
-  insert_cassette("greencow")
+  local_cassette("greencow", warn_on_empty = FALSE)
   response <- x$handle()
 
   expect_s3_class(response, "response")
   # status code is correct
   expect_equal(response$status_code, 404)
-
-  eject_cassette()
 })

--- a/tests/testthat/test-cassette_class.R
+++ b/tests/testthat/test-cassette_class.R
@@ -91,10 +91,7 @@ test_that("cassette checks name", {
     Cassette$new(strrep("x", 400))
   })
 
-  local_vcr_configure(
-    dir = withr::local_tempdir(),
-    warn_on_empty_cassette = FALSE
-  )
+  local_vcr_configure(warn_on_empty_cassette = FALSE)
   local_cassette("foo")
   expect_snapshot(Cassette$new("foo"), error = TRUE)
 })

--- a/tests/testthat/test-cassettes.R
+++ b/tests/testthat/test-cassettes.R
@@ -1,13 +1,8 @@
 test_that("can insert and eject a cassette", {
-  local_vcr_configure(
-    dir = withr::local_tempdir(),
-    warn_on_empty_cassette = FALSE
-  )
-
   expect_false(cassette_active())
   expect_equal(current_cassette(), NULL)
 
-  cassette <- insert_cassette("test")
+  cassette <- insert_cassette("test", warn_on_empty = FALSE)
   expect_s3_class(cassette, "Cassette")
   expect_true(cassette_active())
   expect_equal(current_cassette(), cassette)
@@ -23,10 +18,7 @@ test_that("ejecting errors if no cassettes", {
 })
 
 test_that("inserting a cassette errors when vcr turned off and ignore_cassettes=FALSE", {
-  local_vcr_configure(
-    dir = withr::local_tempdir(),
-    warn_on_empty_cassette = FALSE
-  )
+  local_vcr_configure(warn_on_empty_cassette = FALSE)
   local_light_switch()
 
   # after being turned off, insert_cassette throws an error
@@ -34,7 +26,7 @@ test_that("inserting a cassette errors when vcr turned off and ignore_cassettes=
   expect_snapshot(insert_cassette("test"), error = TRUE)
 
   suppressMessages(turn_off(ignore_cassettes = TRUE))
-  expect_no_error(insert_cassette("test"))
+  expect_no_error(insert_cassette("test", warn_on_empty = FALSE))
 })
 
 test_that("inserting and ejecting is logged", {
@@ -45,21 +37,16 @@ test_that("inserting and ejecting is logged", {
 })
 
 test_that("cassettes are a stack", {
-  local_vcr_configure(
-    dir = withr::local_tempdir(),
-    warn_on_empty_cassette = FALSE
-  )
-
   expect_equal(current_cassette(), NULL)
   expect_equal(cassettes(), list())
   expect_equal(cassette_names(), character(0))
 
-  cassette_a <- insert_cassette("aaa")
+  cassette_a <- insert_cassette("aaa", warn_on_empty = FALSE)
   expect_equal(current_cassette(), cassette_a)
   expect_equal(cassettes(), list(cassette_a))
   expect_equal(cassette_names(), "aaa")
 
-  cassette_b <- insert_cassette("bbb")
+  cassette_b <- insert_cassette("bbb", warn_on_empty = FALSE)
   expect_equal(current_cassette(), cassette_b)
   expect_equal(cassettes(), list(cassette_a, cassette_b))
   expect_equal(cassette_names(), c("aaa", "bbb"))

--- a/tests/testthat/test-errors.R
+++ b/tests/testthat/test-errors.R
@@ -1,8 +1,4 @@
 test_that("UnhandledHTTPRequestError fails well", {
-  local_vcr_configure(
-    dir = withr::local_tempdir(),
-    warn_on_empty_cassette = FALSE
-  )
   request <- Request$new("post", hb("/post?a=5"), "", list(foo = "bar"))
 
   z <- UnhandledHTTPRequestError$new(request)
@@ -11,10 +7,7 @@ test_that("UnhandledHTTPRequestError fails well", {
     "There is currently no cassette in use"
   )
 
-  # insert a cassette
-  cas <- insert_cassette("asdsfd")
-  withr::defer(eject_cassette())
-
+  local_cassette("asdsfd", warn_on_empty = FALSE)
   # # types
   expect_error(
     UnhandledHTTPRequestError$new(5),
@@ -23,13 +16,8 @@ test_that("UnhandledHTTPRequestError fails well", {
 })
 
 test_that("UnhandledHTTPRequestError works as expected", {
-  local_vcr_configure(
-    dir = withr::local_tempdir(),
-    warn_on_empty_cassette = FALSE
-  )
   request <- Request$new("post", hb("/post?a=5"), "", list(foo = "bar"))
-  cas <- insert_cassette("turtle")
-  withr::defer(eject_cassette())
+  local_cassette("turtle", warn_on_empty = FALSE)
 
   a <- UnhandledHTTPRequestError$new(request)
 
@@ -51,12 +39,10 @@ test_that("UnhandledHTTPRequestError works as expected", {
     HELLO_WORLD = "asdfadfasfsfs239823n23"
   )
   local_vcr_configure(
-    dir = withr::local_tempdir(),
     filter_sensitive_data = list(
       "<<foo_bar_key>>" = Sys.getenv("FOO_BAR"),
       "<<hello_world_key>>" = Sys.getenv("HELLO_WORLD")
-    ),
-    warn_on_empty_cassette = FALSE
+    )
   )
   url <- paste0(
     hb("/get?api_key="),
@@ -65,8 +51,7 @@ test_that("UnhandledHTTPRequestError works as expected", {
     Sys.getenv("HELLO_WORLD")
   )
   request <- Request$new("get", url, "")
-  cas <- insert_cassette("bunny")
-  withr::defer(eject_cassette())
+  local_cassette("bunny", warn_on_empty = FALSE)
 
   a <- UnhandledHTTPRequestError$new(request)
 
@@ -95,15 +80,14 @@ test_that("UnhandledHTTPRequestError works as expected", {
   local_vcr_configure(
     dir = withr::local_tempdir(),
     filter_sensitive_data = list("<<foo_bar_key>>" = Sys.getenv("FOO_BAR")),
-    warn_on_empty_cassette = FALSE
   )
   url <- hb("/get")
   request <- Request$new("get", url, "", list(api_key = Sys.getenv("FOO_BAR")))
-  cas <- insert_cassette(
+  local_cassette(
     "frog",
-    match_requests_on = c("method", "uri", "headers")
+    match_requests_on = c("method", "uri", "headers"),
+    warn_on_empty = FALSE
   )
-  withr::defer(eject_cassette())
 
   a <- UnhandledHTTPRequestError$new(request)
 
@@ -126,17 +110,14 @@ test_that("UnhandledHTTPRequestError works as expected", {
   ## API key not found or empty (i.e., "")
   withr::local_envvar(HELLO_MARS = "asdfadfasfsfs239823n23")
   local_vcr_configure(
-    dir = withr::local_tempdir(),
     filter_sensitive_data = list(
       "<<bar_foo_key>>" = Sys.getenv("BAR_FOO"),
       "<<hello_mars_key>>" = Sys.getenv("HELLO_MARS")
-    ),
-    warn_on_empty_cassette = FALSE
+    )
   )
   url <- paste0(hb("/get?api_key="), Sys.getenv("HELLO_MARS"))
   request <- Request$new("get", url, "")
-  cas <- insert_cassette("bunny2")
-  withr::defer(eject_cassette())
+  local_cassette("bunny2", warn_on_empty = FALSE)
 
   a <- UnhandledHTTPRequestError$new(request)
 

--- a/tests/testthat/test-httr.R
+++ b/tests/testthat/test-httr.R
@@ -15,22 +15,16 @@ test_that("httr status code works", {
   expect_error(x$handle())
 
   # do request
-  insert_cassette("greencow")
-  response <- x$handle()
-
+  use_cassette("greencow", response <- x$handle())
   expect_s3_class(response, "response")
   # status code is correct
   expect_equal(response$status_code, 404)
-  eject_cassette()
 
   # call again
-  insert_cassette("greencow")
-  response2 <- x$handle()
-
+  use_cassette("greencow", response2 <- x$handle())
   expect_s3_class(response2, "response")
   # status code is correct
   expect_equal(response2$status_code, 404)
-  eject_cassette()
 })
 
 test_that("httr use_cassette works", {

--- a/tests/testthat/test-lightswitch.R
+++ b/tests/testthat/test-lightswitch.R
@@ -9,12 +9,7 @@ test_that("can turn off and turn on", {
 })
 
 test_that("turned_off works iif no cassettes active", {
-  local_vcr_configure(
-    dir = withr::local_tempdir(),
-    warn_on_empty_cassette = FALSE
-  )
-
-  insert_cassette("test")
+  insert_cassette("test", warn_on_empty = FALSE)
   expect_snapshot(turned_off(5 + 5), error = TRUE)
   eject_cassette()
 

--- a/tests/testthat/test-logger.R
+++ b/tests/testthat/test-logger.R
@@ -17,7 +17,6 @@ test_that("logging is silent unless enabled", {
 })
 
 test_that("vcr_log_sprintf() adds additional metadata", {
-  local_vcr_configure(warn_on_empty_cassette = FALSE)
   local_mocked_bindings(Sys.time = function() as.POSIXct("2024-01-01"))
 
   local_vcr_configure_log(file = stdout(), include_date = FALSE)
@@ -25,7 +24,7 @@ test_that("vcr_log_sprintf() adds additional metadata", {
 
   # Turn logging off and add a cassette
   local_vcr_configure_log(log = FALSE)
-  local_cassette("testing")
+  local_cassette("testing", warn_on_empty = FALSE)
 
   local_vcr_configure_log(file = stdout(), include_date = TRUE)
   expect_snapshot(vcr_log_sprintf("log"))

--- a/tests/testthat/test-vcr_last_error.R
+++ b/tests/testthat/test-vcr_last_error.R
@@ -1,21 +1,13 @@
 test_that("vcr_last_error fails well", {
-  local_vcr_configure(
-    dir = withr::local_tempdir(),
-    warn_on_empty_cassette = FALSE
-  )
   the$last_error <- list()
-
   expect_error(vcr_last_error(), "no error to report")
 
   # insert  a cassette - same result
-  cas <- suppressMessages(insert_cassette("rabbit"))
-  withr::defer(eject_cassette())
+  local_cassette("rabbit", warn_on_empty = FALSE)
   expect_error(vcr_last_error(), "no error to report")
 })
 
 test_that("vcr_last_error works: no casssette in use yet", {
-  local_vcr_configure(dir = withr::local_tempdir())
-
   request <- Request$new("post", hb("/post?a=5"), "", list(foo = "bar"))
   err <- UnhandledHTTPRequestError$new(request)
   expect_error(err$construct_message())
@@ -25,10 +17,9 @@ test_that("vcr_last_error works: no casssette in use yet", {
 })
 
 test_that("vcr_last_error works: casssette in use", {
-  local_vcr_configure(dir = withr::local_tempdir())
   request <- Request$new("post", hb("/post?a=5"), "", list(foo = "bar"))
 
-  cas <- insert_cassette("bunny")
+  local_cassette("bunny", warn_on_empty = FALSE)
   err <- UnhandledHTTPRequestError$new(request)
   expect_error(err$construct_message())
   expect_message(


### PR DESCRIPTION
This allows us to eliminate the use of `local_vcr_configuration()` in a number of tests. While I was touching these tests, I also took the opportunity to review where we could use other new tools like `local_cassette()`, and where we no longer need to set the cassette dir since we only write a file if an interaction is recorded.
