### PR TITLE
Move `sensitive_remove()` into encoding for body/uri/headers

### DIFF
--- a/R/configuration.R
+++ b/R/configuration.R
@@ -296,7 +296,11 @@ VCRConfig <- R6::R6Class(
     },
     filter_sensitive_data = function(value) {
       if (missing(value)) return(private$.filter_sensitive_data)
-      private$.filter_sensitive_data <- assert(value, "list")
+      assert(value, "list")
+      for (i in seq_along(value)) {
+        value[[i]] <- trimquotes(value[[i]], names(value)[i])
+      }
+      private$.filter_sensitive_data <- value
     },
     filter_sensitive_data_regex = function(value) {
       if (missing(value)) return(private$.filter_sensitive_data_regex)

--- a/R/filter_query_parameters.R
+++ b/R/filter_query_parameters.R
@@ -1,6 +1,6 @@
 #' Remove or replace query parameters
 #' @noRd
-query_params_remove <- function(
+encode_uri <- function(
   uri,
   filter = vcr_c$filter_query_parameters,
   flip = FALSE
@@ -25,6 +25,8 @@ query_params_remove <- function(
       uri <- replace_param(uri, names(to_replace)[[i]], val)
     }
   }
+
+  uri <- sensitive_remove(uri)
 
   uri
 }

--- a/R/filter_sensitive_data.R
+++ b/R/filter_sensitive_data.R
@@ -4,7 +4,7 @@ trimquotes <- function(x, y) {
     msg <- "filter_sensitive_data: leading & trailing quotes trimmed from '"
     warning(paste0(msg, y, "'"), call. = FALSE)
   }
-  return(gsub(pattern, "", x))
+  gsub(pattern, "", x)
 }
 
 # filter_sensitive_data replacement
@@ -21,20 +21,16 @@ sensitive_put_back <- function(x) {
 }
 sensitive_remove <- function(x) {
   fsd <- vcr_c$filter_sensitive_data
-  if (!is.null(fsd)) {
-    for (i in seq_along(fsd)) {
-      if (nchar(fsd[[i]]) > 0) {
-        strg <- trimquotes(fsd[[i]], names(fsd)[i])
-        x <- gsub(strg, names(fsd)[i], x, fixed = TRUE)
-      }
+  for (i in seq_along(fsd)) {
+    if (nchar(fsd[[i]]) > 0) {
+      x <- gsub(fsd[[i]], names(fsd)[i], x, fixed = TRUE)
     }
   }
+
   fsdr <- vcr_c$filter_sensitive_data_regex
-  if (!is.null(fsdr)) {
-    for (i in seq_along(fsdr)) {
-      if (nchar(fsdr[[i]]) > 0) {
-        x <- gsub(fsdr[[i]], names(fsdr)[i], x, fixed = FALSE)
-      }
+  for (i in seq_along(fsdr)) {
+    if (nchar(fsdr[[i]]) > 0) {
+      x <- gsub(fsdr[[i]], names(fsdr)[i], x, fixed = FALSE)
     }
   }
   return(x)

--- a/R/request_matcher_registry.R
+++ b/R/request_matcher_registry.R
@@ -53,7 +53,7 @@ RequestMatcherRegistry <- R6::R6Class(
         "uri",
         function(r1, r2)
           identical(
-            curl::curl_unescape(query_params_remove(r1$uri, flip = TRUE)),
+            curl::curl_unescape(encode_uri(r1$uri, flip = TRUE)),
             curl::curl_unescape(r2$uri)
           )
       )

--- a/R/write.R
+++ b/R/write.R
@@ -33,9 +33,8 @@ dedup_keys <- function(x) {
   return(x)
 }
 
-encode_interactions <- function(x, file, bytes) {
+encode_interactions <- function(x, bytes) {
   assert(x, c("list", "HTTPInteraction"))
-  assert(file, "character")
 
   list(
     list(
@@ -99,13 +98,13 @@ encode_body <- function(body, file, preserve_bytes = FALSE) {
 # param file: a file path
 # param bytes: logical, whether to preserve exact bytes or not
 write_interactions <- function(x, file, bytes) {
-  z <- encode_interactions(x, file, bytes)
+  z <- encode_interactions(x, bytes)
   tmp <- yaml::as.yaml(z)
   cat(tmp, file = file, append = TRUE)
 }
 
 write_interactions_json <- function(x, file, bytes) {
-  z <- encode_interactions(x, file, bytes)
+  z <- encode_interactions(x, bytes)
   # combine with existing data on same file, if any
   on_disk <- invisible(tryCatch(
     jsonlite::fromJSON(file, FALSE),

--- a/tests/testthat/_snaps/configuration.md
+++ b/tests/testthat/_snaps/configuration.md
@@ -1,0 +1,8 @@
+# filter_sensitive data strips quotes with message
+
+    Code
+      vcr_configure(filter_sensitive_data = list(key = "\"val\""))
+    Condition
+      Warning:
+      filter_sensitive_data: leading & trailing quotes trimmed from 'key'
+

--- a/tests/testthat/_snaps/filter-sensitive-strings.md
+++ b/tests/testthat/_snaps/filter-sensitive-strings.md
@@ -1,9 +1,0 @@
-# filter sensitive data strips leading/trailing single/double quotes
-
-    Code
-      cas <- use_cassette("testing2", res <- x$get("get", query = list(key = Sys.getenv(
-        "MY_KEY_ON_GH_ACTIONS"))))
-    Condition
-      Warning:
-      filter_sensitive_data: leading & trailing quotes trimmed from '<somekey>'
-

--- a/tests/testthat/test-configuration.R
+++ b/tests/testthat/test-configuration.R
@@ -71,6 +71,13 @@ test_that("can temporarily change configuration", {
   expect_equal(cassette_path(), "a")
 })
 
+test_that("filter_sensitive data strips quotes with message", {
+  local_vcr_configure()
+
+  expect_snapshot(vcr_configure(filter_sensitive_data = list("key" = '"val"')))
+  expect_equal(vcr_configuration()$filter_sensitive_data, list("key" = "val"))
+})
+
 test_that("all configuration params are documented", {
   rd_file <- "../../man/vcr_configure.Rd"
   skip_if_not(file.exists(rd_file), sprintf("Did not find: '%s'", rd_file))

--- a/tests/testthat/test-filter-sensitive-strings.R
+++ b/tests/testthat/test-filter-sensitive-strings.R
@@ -1,5 +1,3 @@
-skip_on_cran()
-
 test_that("filter sensitive strings", {
   x <- "foo234223){@%!kl]bar"
 
@@ -36,33 +34,4 @@ test_that("filter sensitive regex strings", {
   # There's no way to put back the real string unless
   # we stored it somehow, but that seems like an added security risk
   # expect_identical(sensitive_put_back(sensitive_remove(x)), x)
-})
-
-test_that("filter sensitive data strips leading/trailing single/double quotes", {
-  withr::local_envvar(MY_KEY_ON_GH_ACTIONS = "\"ab123c\"")
-  tmpdir <- withr::local_tempdir()
-  local_vcr_configure(
-    dir = withr::local_tempdir(),
-    filter_sensitive_data = list(
-      "<somekey>" = Sys.getenv("MY_KEY_ON_GH_ACTIONS")
-    )
-  )
-  x <- crul::HttpClient$new("https://hb.opencpu.org")
-  expect_snapshot(
-    cas <- use_cassette(
-      "testing2",
-      res <- x$get(
-        "get",
-        query = list(key = Sys.getenv("MY_KEY_ON_GH_ACTIONS"))
-      )
-    )
-  )
-  int <- yaml::yaml.load_file(cas$file())$http_interactions[[1]]
-  expect_false(grepl(
-    Sys.getenv("MY_KEY_ON_GH_ACTIONS"),
-    URLdecode(int$request$uri)
-  ))
-  body <- jsonlite::fromJSON(int$response$body$string)
-  expect_false(grepl(Sys.getenv("MY_KEY_ON_GH_ACTIONS"), body$args$key))
-  expect_false(grepl(Sys.getenv("MY_KEY_ON_GH_ACTIONS"), body$url))
 })


### PR DESCRIPTION
A few small changes along the way:

* Rename `query_params_remove()` to `encode_uri()`.
* Trim quotes in `vcr_configure()`.
* Rename `prep_interaction()` to `encode_interactions()`.
