### PR TITLE
Drop `to_hash()` and `from_hash()`

### DIFF
--- a/R/http_interaction.R
+++ b/R/http_interaction.R
@@ -1,16 +1,6 @@
 #' @title HTTPInteraction class
 #' @description object holds request and response objects
 #' @export
-#' @details
-#' \strong{Methods}
-#'   \describe{
-#'     \item{\code{to_hash()}}{
-#'       Create a hash from the HTTPInteraction object
-#'     }
-#'     \item{\code{from_hash(hash)}}{
-#'       Create a HTTPInteraction object from a hash
-#'     }
-#'   }
 #' @examples \dontrun{
 #' # make the request
 #' library(vcr)
@@ -32,14 +22,6 @@
 #' # make HTTPInteraction object
 #' (x <- HTTPInteraction$new(request = request, response = response))
 #' x$recorded_at
-#' x$to_hash()
-#'
-#' # make an HTTPInteraction from a hash with the object already made
-#' x$from_hash(x$to_hash())
-#'
-#' # Make an HTTPInteraction from a hash alone
-#' my_hash <- x$to_hash()
-#' HTTPInteraction$new()$from_hash(my_hash)
 #' }
 HTTPInteraction <- R6::R6Class(
   'HTTPInteraction',
@@ -60,16 +42,6 @@ HTTPInteraction <- R6::R6Class(
       if (!missing(request)) self$request <- request
       if (!missing(response)) self$response <- response
       self$recorded_at <- Sys.time()
-    },
-
-    #' @description Create a hash from the HTTPInteraction object
-    #' @return a named list
-    to_hash = function() {
-      list(
-        request = self$request$to_hash(),
-        response = self$response$to_hash(),
-        recorded_at = self$recorded_at
-      )
     }
   )
 )

--- a/R/http_interaction_list.R
+++ b/R/http_interaction_list.R
@@ -29,9 +29,6 @@ NullList <- R6::R6Class(
 #'     \item{\code{interaction_matches_request(request, interaction)}}{
 #'       Check if a request matches an interaction (logical)
 #'     }
-#'     \item{\code{from_hash()}}{
-#'       Get a hash back.
-#'     }
 #'     \item{\code{request_summary(z)}}{
 #'       Get a request summary (character)
 #'     }
@@ -121,8 +118,8 @@ HTTPInteractionList <- R6::R6Class(
         function(x) {
           sprintf(
             "%s => %s",
-            request_summary(Request$new()$from_hash(x$request)),
-            response_summary(VcrResponse$new()$from_hash(x$response))
+            request_summary(x$request),
+            response_summary(x$response)
           )
         },
         ""
@@ -154,9 +151,9 @@ HTTPInteractionList <- R6::R6Class(
         )
         vcr_log_sprintf(
           "  Found matching interaction for %s at index %s: %s",
-          request_summary(Request$new()$from_hash(request)),
+          request_summary(request),
           index,
-          response_summary(VcrResponse$new()$from_hash(interaction$response))
+          response_summary(interaction$response)
         )
         interaction$response
       } else {

--- a/R/request_class.R
+++ b/R/request_class.R
@@ -18,8 +18,6 @@
 #' x$host
 #' x$path
 #' x$headers
-#' h <- x$to_hash()
-#' x$from_hash(h)
 Request <- R6::R6Class(
   'Request',
   public = list(
@@ -101,31 +99,6 @@ Request <- R6::R6Class(
       if (!missing(fields)) self$fields <- fields
       if (!missing(output)) self$output <- output
       if (!missing(policies)) self$policies <- policies
-    },
-
-    #' @description Convert the request to a list
-    #' @return list
-    to_hash = function() {
-      list(
-        method = self$method,
-        uri = self$uri,
-        body = self$body,
-        headers = self$headers,
-        disk = self$disk
-      )
-    },
-
-    #' @description Convert the request to a list
-    #' @param hash a list
-    #' @return a new `Request` object
-    from_hash = function(hash) {
-      Request$new(
-        method = hash[['method']],
-        uri = hash[['uri']],
-        body = hash[['body']] %||% "",
-        headers = hash[['headers']],
-        disk = hash[['disk']]
-      )
     }
   ),
   private = list(

--- a/R/request_handler.R
+++ b/R/request_handler.R
@@ -120,7 +120,7 @@ RequestHandler <- R6::R6Class(
   private = list(
     request_summary = function(request) {
       request_matches <- current_casssette()$match_requests_on
-      request_summary(Request$new()$from_hash(request), request_matchers)
+      request_summary(request, request_matchers)
     },
 
     request_type = function() {

--- a/R/request_response.R
+++ b/R/request_response.R
@@ -57,7 +57,6 @@
 #' # (x <- VcrResponse$new(status, headers, png_eg, "HTTP/1.1 200 OK"))
 #' # response_summary(x)
 request_summary <- function(request, request_matchers = "") {
-  stopifnot(inherits(request, "Request"))
   stopifnot(inherits(request_matchers, "character"))
   atts <- c(request$method, request$uri)
   if ("body" %in% request_matchers) {
@@ -82,7 +81,13 @@ response_summary <- function(response) {
   }
 
   # if body is raw, state that it's raw
-  resp <- if (is.raw(response$body)) "<raw>" else response$body
+  if (is.null(response$body)) {
+    resp <- ""
+  } else if (is.raw(response$body)) {
+    resp <- "<raw>"
+  } else {
+    resp <- response$body
+  }
 
   # construct summary
   # note: gsub changes a string to UTF-8, useBytes seems to avoid doing this

--- a/R/response_class.R
+++ b/R/response_class.R
@@ -14,8 +14,6 @@
 #' x$body
 #' x$status
 #' x$headers
-#' x$to_hash()
-#' x$from_hash(x$to_hash())
 #'
 #' # check if body is compressed
 #' url <- "https://fishbase.ropensci.org"
@@ -74,29 +72,6 @@ VcrResponse <- R6::R6Class(
     #' @description print method for the `VcrResponse` class
     #' @param x self
     #' @param ... ignored
-    print = function(x, ...) cat("<VcrResponse> ", sep = "\n"),
-
-    #' @description Create a hash
-    #' @return a list
-    to_hash = function() {
-      list(
-        status = self$status,
-        headers = self$headers,
-        body = self$body,
-        disk = self$disk
-      )
-    },
-
-    #' @description Get a hash back to an R list
-    #' @param hash a list
-    #' @return an `VcrResponse` object
-    from_hash = function(hash) {
-      VcrResponse$new(
-        hash[["status"]],
-        hash[["headers"]],
-        hash[["body"]] %||% "",
-        hash[["disk"]]
-      )
-    }
+    print = function(x, ...) cat("<VcrResponse> ", sep = "\n")
   )
 )

--- a/man/HTTPInteraction.Rd
+++ b/man/HTTPInteraction.Rd
@@ -6,17 +6,6 @@
 \description{
 object holds request and response objects
 }
-\details{
-\strong{Methods}
-\describe{
-\item{\code{to_hash()}}{
-Create a hash from the HTTPInteraction object
-}
-\item{\code{from_hash(hash)}}{
-Create a HTTPInteraction object from a hash
-}
-}
-}
 \examples{
 \dontrun{
 # make the request
@@ -39,14 +28,6 @@ res <- cli$post(body = body)
 # make HTTPInteraction object
 (x <- HTTPInteraction$new(request = request, response = response))
 x$recorded_at
-x$to_hash()
-
-# make an HTTPInteraction from a hash with the object already made
-x$from_hash(x$to_hash())
-
-# Make an HTTPInteraction from a hash alone
-my_hash <- x$to_hash()
-HTTPInteraction$new()$from_hash(my_hash)
 }
 }
 \section{Public fields}{
@@ -64,7 +45,6 @@ HTTPInteraction$new()$from_hash(my_hash)
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-HTTPInteraction-new}{\code{HTTPInteraction$new()}}
-\item \href{#method-HTTPInteraction-to_hash}{\code{HTTPInteraction$to_hash()}}
 \item \href{#method-HTTPInteraction-clone}{\code{HTTPInteraction$clone()}}
 }
 }
@@ -90,19 +70,6 @@ Create a new \code{HTTPInteraction} object
 }
 \subsection{Returns}{
 A new \code{HTTPInteraction} object
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-HTTPInteraction-to_hash"></a>}}
-\if{latex}{\out{\hypertarget{method-HTTPInteraction-to_hash}{}}}
-\subsection{Method \code{to_hash()}}{
-Create a hash from the HTTPInteraction object
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{HTTPInteraction$to_hash()}\if{html}{\out{</div>}}
-}
-
-\subsection{Returns}{
-a named list
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/HTTPInteractionList.Rd
+++ b/man/HTTPInteractionList.Rd
@@ -21,9 +21,6 @@ asdfadfs
 \item{\code{interaction_matches_request(request, interaction)}}{
 Check if a request matches an interaction (logical)
 }
-\item{\code{from_hash()}}{
-Get a hash back.
-}
 \item{\code{request_summary(z)}}{
 Get a request summary (character)
 }

--- a/man/Request.Rd
+++ b/man/Request.Rd
@@ -22,8 +22,6 @@ x$uri
 x$host
 x$path
 x$headers
-h <- x$to_hash()
-x$from_hash(h)
 }
 \keyword{internal}
 \section{Public fields}{
@@ -63,8 +61,6 @@ x$from_hash(h)
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-Request-new}{\code{Request$new()}}
-\item \href{#method-Request-to_hash}{\code{Request$to_hash()}}
-\item \href{#method-Request-from_hash}{\code{Request$from_hash()}}
 \item \href{#method-Request-clone}{\code{Request$clone()}}
 }
 }
@@ -114,39 +110,6 @@ default: \code{FALSE}}
 }
 \subsection{Returns}{
 A new \code{Request} object
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Request-to_hash"></a>}}
-\if{latex}{\out{\hypertarget{method-Request-to_hash}{}}}
-\subsection{Method \code{to_hash()}}{
-Convert the request to a list
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Request$to_hash()}\if{html}{\out{</div>}}
-}
-
-\subsection{Returns}{
-list
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-Request-from_hash"></a>}}
-\if{latex}{\out{\hypertarget{method-Request-from_hash}{}}}
-\subsection{Method \code{from_hash()}}{
-Convert the request to a list
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Request$from_hash(hash)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{hash}}{a list}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-a new \code{Request} object
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/VcrResponse.Rd
+++ b/man/VcrResponse.Rd
@@ -19,8 +19,6 @@ url <- "https://google.com"
 x$body
 x$status
 x$headers
-x$to_hash()
-x$from_hash(x$to_hash())
 
 # check if body is compressed
 url <- "https://fishbase.ropensci.org"
@@ -60,8 +58,6 @@ f <- tempfile()
 \itemize{
 \item \href{#method-VcrResponse-new}{\code{VcrResponse$new()}}
 \item \href{#method-VcrResponse-print}{\code{VcrResponse$print()}}
-\item \href{#method-VcrResponse-to_hash}{\code{VcrResponse$to_hash()}}
-\item \href{#method-VcrResponse-from_hash}{\code{VcrResponse$from_hash()}}
 \item \href{#method-VcrResponse-clone}{\code{VcrResponse$clone()}}
 }
 }
@@ -108,39 +104,6 @@ print method for the \code{VcrResponse} class
 \item{\code{...}}{ignored}
 }
 \if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-VcrResponse-to_hash"></a>}}
-\if{latex}{\out{\hypertarget{method-VcrResponse-to_hash}{}}}
-\subsection{Method \code{to_hash()}}{
-Create a hash
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{VcrResponse$to_hash()}\if{html}{\out{</div>}}
-}
-
-\subsection{Returns}{
-a list
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-VcrResponse-from_hash"></a>}}
-\if{latex}{\out{\hypertarget{method-VcrResponse-from_hash}{}}}
-\subsection{Method \code{from_hash()}}{
-Get a hash back to an R list
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{VcrResponse$from_hash(hash)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{hash}}{a list}
-}
-\if{html}{\out{</div>}}
-}
-\subsection{Returns}{
-an \code{VcrResponse} object
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-HttpInteraction.R
+++ b/tests/testthat/test-HttpInteraction.R
@@ -28,11 +28,6 @@ test_that("HttpInteraction", {
   expect_type(x$recorded_at, 'double')
 
   # methods and objects
-  expect_type(x$to_hash, "closure")
   expect_s3_class(x$request, "Request")
   expect_s3_class(x$response, "VcrResponse")
-
-  # to_hash method
-  expect_type(x$to_hash(), "list")
-  expect_named(x$to_hash(), c('request', 'response', 'recorded_at'))
 })

--- a/tests/testthat/test-Request.R
+++ b/tests/testthat/test-Request.R
@@ -14,10 +14,6 @@ test_that("Request basic stuff", {
   expect_null(aa$scheme)
   expect_null(aa$uri)
   expect_false(aa$skip_port_stripping)
-
-  # methods
-  expect_type(aa$from_hash, "closure")
-  expect_type(aa$to_hash, "closure")
 })
 
 test_that("Request usage", {
@@ -36,12 +32,6 @@ test_that("Request usage", {
   expect_equal(aa$path, "post")
   expect_type(aa$headers, "list")
   expect_true("User-Agent" %in% names(aa$headers))
-  h <- aa$to_hash()
-  expect_type(h, "list")
-  zz <- aa$from_hash(h)
-  expect_s3_class(zz, "Request")
-  # equal but not identical
-  expect_equal(zz, aa)
 })
 
 test_that("Request fails well", {
@@ -49,6 +39,4 @@ test_that("Request fails well", {
 
   z <- Request$new()
   expect_error(z$foo(), "attempt to apply non-function")
-  expect_error(z$from_hash(), "missing")
-  expect_error(z$to_hash(4), "unused argument")
 })

--- a/tests/testthat/test-RequestMatcherRegistry.R
+++ b/tests/testthat/test-RequestMatcherRegistry.R
@@ -1,39 +1,34 @@
 test_that("RequestMatcherRegistry basic functionality works", {
-  one <- list(
+  a <- Request$new(
     method = "get",
     uri = "http://foo.bar",
     body = '{"key": "value"}',
     headers = list(a = 5, b = 6)
   )
-  two <- list(
+  b <- Request$new(
     method = "post",
     uri = "http://foo.bar/world",
     body = '{"key": "value"}',
     headers = list(a = 5, c = 7)
   )
-  three <- list(
+  c <- Request$new(
     method = "get",
     uri = "http://foo.bar?stuff=things",
     body = '{"key": "another-value"}',
     headers = list(a = 5, c = 7)
   )
-  four <- list(
+  d <- Request$new(
     method = "post",
     uri = "http://foo.bar?stuff=things7",
     body = '{"key": "another-value"}',
     headers = list(a = 5, c = 7)
   )
-  five <- list(
+  e <- Request$new(
     method = "post",
     uri = "http://foo.bar/world?stuff=things7",
     body = '{"key": "another-value"}',
     headers = list(a = 5, c = 7)
   )
-  a <- Request$new()$from_hash(one)
-  b <- Request$new()$from_hash(two)
-  c <- Request$new()$from_hash(three)
-  d <- Request$new()$from_hash(four)
-  e <- Request$new()$from_hash(five)
 
   # method
   rm <- RequestMatcherRegistry$new()

--- a/tests/testthat/test-httr2.R
+++ b/tests/testthat/test-httr2.R
@@ -3,9 +3,9 @@ skip_on_cran()
 test_that("httr2 status code works", {
   local_vcr_configure(dir = withr::local_tempdir())
 
-  # httr2_obj <- request(hb("/getttttt"))
+  httr2_obj <- httr2::request(hb("/getttttt"))
   # save(httr2_obj, file="tests/testthat/httr2_obj.rda", version = 2L)
-  load("httr2_obj.rda")
+  # load("httr2_obj.rda")
 
   expect_s3_class(httr2_obj, "httr2_request")
 

--- a/tests/testthat/test-request_summary.R
+++ b/tests/testthat/test-request_summary.R
@@ -44,5 +44,4 @@ test_that("request_summary works", {
 
 test_that("request_summary fails well", {
   expect_error(request_summary(), "\"request\" is missing")
-  expect_error(request_summary(5), "is not TRUE")
 })

--- a/tests/testthat/test-write_interactions.R
+++ b/tests/testthat/test-write_interactions.R
@@ -31,7 +31,6 @@ response <- VcrResponse$new(
   resp_body
 )
 x <- HTTPInteraction$new(request = request, response = response)
-x <- x$to_hash()
 
 test_that("write_interactions works as expected", {
   tfile <- withr::local_tempfile()


### PR DESCRIPTION
It seems like these aren't currently needed because the request object and corresponding list are similar enough.
