### PR TITLE
Refactor `RequestHandler`

### DIFF
--- a/R/request_handler-crul.R
+++ b/R/request_handler-crul.R
@@ -5,18 +5,18 @@ RequestHandlerCrul <- R6::R6Class(
   'RequestHandlerCrul',
   inherit = RequestHandler,
   private = list(
-    on_ignored_request = function(request) {
+    on_ignored_request = function() {
       tmp2 <- webmockr::webmockr_crul_fetch(self$request_original)
       response <- webmockr::build_crul_response(self$request_original, tmp2)
       return(response)
     },
 
-    on_stubbed_by_vcr_request = function(request) {
+    on_stubbed_by_vcr_request = function() {
       # return stubbed vcr response - no real response to do
-      serialize_to_crul(request, super$get_stubbed_response(request))
+      serialize_to_crul(self$request, super$get_stubbed_response(self$request))
     },
 
-    on_recordable_request = function(request) {
+    on_recordable_request = function() {
       tmp2 <- webmockr::webmockr_crul_fetch(self$request_original)
       response <- webmockr::build_crul_response(self$request_original, tmp2)
 

--- a/R/request_handler-httr.R
+++ b/R/request_handler-httr.R
@@ -58,7 +58,7 @@ RequestHandlerHttr <- R6::R6Class(
 
   private = list(
     # these will replace those in
-    on_ignored_request = function(request) {
+    on_ignored_request = function() {
       # perform and return REAL http response
       # * make real request
       # * give back real response
@@ -66,23 +66,23 @@ RequestHandlerHttr <- R6::R6Class(
       # real request
       webmockr::httr_mock(FALSE)
       on.exit(webmockr::httr_mock(TRUE), add = TRUE)
-      tmp2 <- eval(parse(text = paste0("httr::", request$method)))(
-        request$url,
-        body = take_body(request),
-        do.call(httr::config, request$options),
-        httr::add_headers(request$headers)
+      tmp2 <- eval(parse(text = paste0("httr::", self$request$method)))(
+        self$request$url,
+        body = take_body(self$request),
+        do.call(httr::config, self$request$options),
+        httr::add_headers(self$request$headers)
       )
 
       # return real response
       return(response)
     },
 
-    on_stubbed_by_vcr_request = function(request) {
+    on_stubbed_by_vcr_request = function() {
       # return stubbed vcr response - no real response to do
-      serialize_to_httr(request, super$get_stubbed_response(request))
+      serialize_to_httr(self$request, super$get_stubbed_response(self$request))
     },
 
-    on_recordable_request = function(request) {
+    on_recordable_request = function() {
       # do real request - then stub response - then return stubbed vcr response
       # - this may need to be called from webmockr httradapter?
 

--- a/R/request_handler-httr2.R
+++ b/R/request_handler-httr2.R
@@ -51,7 +51,7 @@ RequestHandlerHttr2 <- R6::R6Class(
 
   private = list(
     # these will replace those in
-    on_ignored_request = function(request) {
+    on_ignored_request = function() {
       # perform and return REAL http response
       # * make real request
       # * give back real response
@@ -59,19 +59,19 @@ RequestHandlerHttr2 <- R6::R6Class(
       # real request
       webmockr::httr2_mock(FALSE)
       on.exit(webmockr::httr2_mock(TRUE), add = TRUE)
-      response <- httr2::req_perform(request)
+      response <- httr2::req_perform(self$request)
 
       # return real response
       return(response)
     },
 
-    on_stubbed_by_vcr_request = function(request) {
+    on_stubbed_by_vcr_request = function() {
       # print("------- on_stubbed_by_vcr_request -------")
       # return stubbed vcr response - no real response to do
-      serialize_to_httr2(request, super$get_stubbed_response(request))
+      serialize_to_httr2(self$request, super$get_stubbed_response(self$request))
     },
 
-    on_recordable_request = function(request) {
+    on_recordable_request = function() {
       # print("------- on_recordable_request -------")
       # do real request - then stub response - then return stubbed vcr response
       # real request

--- a/tests/testthat/test-RequestHandler.R
+++ b/tests/testthat/test-RequestHandler.R
@@ -16,10 +16,7 @@ test_that("RequestHandlerHttr: httr", {
 
   load("httr_obj.rda")
   x <- RequestHandlerHttr$new(httr_obj)
-
   expect_s3_class(x, "RequestHandlerHttr")
-  expect_type(x$handle, "closure")
-  expect_error(x$handle())
 
   # do request
   local_cassette("greencow", warn_on_empty = FALSE)

--- a/tests/testthat/test-ause_cassette_match_requests_on_json.R
+++ b/tests/testthat/test-ause_cassette_match_requests_on_json.R
@@ -91,7 +91,11 @@ test_that("use_cassette: match_requests_on - JSON-encoded body w/ httr", {
   expect_error(
     use_cassette(
       "testing2",
-      res <- httr::POST(hb("/post"), body = list(foo = "bar1"), encode = "json"),
+      res <- httr::POST(
+        hb("/post"),
+        body = list(foo = "bar1"),
+        encode = "json"
+      ),
       match_requests_on = "body"
     ),
     "An HTTP request has been made that vcr does not know how to handle"

--- a/tests/testthat/test-request_handler-httr.R
+++ b/tests/testthat/test-request_handler-httr.R
@@ -9,10 +9,7 @@ test_that("httr status code works", {
   expect_s3_class(httr_obj, "request")
 
   x <- RequestHandlerHttr$new(httr_obj)
-
   expect_s3_class(x, "RequestHandlerHttr")
-  expect_type(x$handle, "closure")
-  expect_error(x$handle())
 
   # do request
   use_cassette("greencow", response <- x$handle())

--- a/tests/testthat/test-request_handler-httr2.R
+++ b/tests/testthat/test-request_handler-httr2.R
@@ -10,10 +10,7 @@ test_that("httr2 status code works", {
   expect_s3_class(httr2_obj, "httr2_request")
 
   x <- RequestHandlerHttr2$new(httr2_obj)
-
   expect_s3_class(x, "RequestHandlerHttr2")
-  expect_type(x$handle, "closure")
-  expect_error(x$handle())
 
   # do request
   insert_cassette("bluecow")


### PR DESCRIPTION
* Remove a layer of indirection and call private methods directly
* Use `self$request` rather than passing `request` object again
