### PR TITLE
Drop unusued `Request()` fields

### DIFF
--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -415,7 +415,6 @@ Cassette <- R6::R6Class(
           z$request$uri,
           z$request$body$string,
           z$request$headers,
-          disk = z$response$body$file
         )
         if (should_be_ignored(request)) {
           return(NULL)
@@ -512,7 +511,6 @@ Cassette <- R6::R6Class(
         } else {
           x$request_headers
         },
-        disk = is_disk,
         skip_port_stripping = TRUE
       )
 

--- a/R/request_class.R
+++ b/R/request_class.R
@@ -56,10 +56,6 @@ Request <- R6::R6Class(
     #' @param uri (character) request URI
     #' @param body (character) request body
     #' @param headers (named list) request headers
-    #' @param disk (boolean), is body a file on disk
-    #' @param fields (various) post fields
-    #' @param output (various) output details
-    #' @param policies (various) http policies, used in httr2 only
     #' @param skip_port_stripping (logical) whether to strip the port.
     #' default: `FALSE`
     #' @return A new `Request` object
@@ -68,10 +64,6 @@ Request <- R6::R6Class(
       uri,
       body,
       headers,
-      disk,
-      fields,
-      output,
-      policies,
       skip_port_stripping = FALSE
     ) {
       if (!missing(method)) self$method <- tolower(method)
@@ -95,10 +87,6 @@ Request <- R6::R6Class(
         self$path <- tmp$path
         self$query <- tmp$parameter
       }
-      if (!missing(disk)) self$disk <- disk
-      if (!missing(fields)) self$fields <- fields
-      if (!missing(output)) self$output <- output
-      if (!missing(policies)) self$policies <- policies
     }
   ),
   private = list(

--- a/R/request_handler-httr.R
+++ b/R/request_handler-httr.R
@@ -48,9 +48,7 @@ RequestHandlerHttr <- R6::R6Class(
           request$method,
           request$url,
           take_body(request),
-          request$headers,
-          fields = request$fields,
-          output = request$output
+          request$headers
         )
       }
     }

--- a/R/request_handler-httr2.R
+++ b/R/request_handler-httr2.R
@@ -41,9 +41,7 @@ RequestHandlerHttr2 <- R6::R6Class(
           request$method,
           request$url,
           take_body(request),
-          request$headers,
-          fields = request$fields,
-          policies = request$policies
+          request$headers
         )
       }
     }

--- a/R/request_handler.R
+++ b/R/request_handler.R
@@ -55,8 +55,7 @@ RequestHandler <- R6::R6Class(
           request$method,
           request$url$url %||% request$url,
           take_body(request) %||% "",
-          request$headers,
-          disk = !is.null(request$output$path)
+          request$headers
         )
       }
     },

--- a/man/Request.Rd
+++ b/man/Request.Rd
@@ -70,17 +70,7 @@ x$headers
 \subsection{Method \code{new()}}{
 Create a new \code{Request} object
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Request$new(
-  method,
-  uri,
-  body,
-  headers,
-  disk,
-  fields,
-  output,
-  policies,
-  skip_port_stripping = FALSE
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Request$new(method, uri, body, headers, skip_port_stripping = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -94,14 +84,6 @@ post, put, patch or delete)}
 \item{\code{body}}{(character) request body}
 
 \item{\code{headers}}{(named list) request headers}
-
-\item{\code{disk}}{(boolean), is body a file on disk}
-
-\item{\code{fields}}{(various) post fields}
-
-\item{\code{output}}{(various) output details}
-
-\item{\code{policies}}{(various) http policies, used in httr2 only}
 
 \item{\code{skip_port_stripping}}{(logical) whether to strip the port.
 default: \code{FALSE}}


### PR DESCRIPTION
The primary job of the request object is to support request matching, so these extra fields are not needed.