### PR TITLE
Improve Request/Response serialisation

### DIFF
--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -32,7 +32,7 @@ Cassette <- R6::R6Class(
     #' @field serialize_with (character) serializer to use (yaml|json)
     serialize_with = "yaml",
     #' @field serializer (character) serializer to use (yaml|json)
-    serializer = NA,
+  serializer = NA,
     #' @field match_requests_on (character) matchers to use
     #' default: method & uri
     match_requests_on = c("method", "uri"),

--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -325,26 +325,7 @@ Cassette <- R6::R6Class(
       if (self$is_empty()) return(list())
 
       interactions <- self$serializer$deserialize()$http_interactions
-
-      compact(lapply(interactions, function(z) {
-        request <- Request$new(
-          z$request$method,
-          z$request$uri,
-          z$request$body$string,
-          z$request$headers
-        )
-        if (should_be_ignored(request)) {
-          return(NULL)
-        }
-
-        response <- VcrResponse$new(
-          z$response$status,
-          z$response$headers,
-          z$response$body$string %||% z$response$body$base64_string,
-          disk = z$response$body$file
-        )
-        list(request = request, response = response)
-      }))
+      Filter(\(x) !should_be_ignored(x$request), interactions)
     },
 
     #' @description write recorded interactions to disk

--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -32,7 +32,7 @@ Cassette <- R6::R6Class(
     #' @field serialize_with (character) serializer to use (yaml|json)
     serialize_with = "yaml",
     #' @field serializer (character) serializer to use (yaml|json)
-  serializer = NA,
+    serializer = NA,
     #' @field match_requests_on (character) matchers to use
     #' default: method & uri
     match_requests_on = c("method", "uri"),

--- a/R/filter_sensitive_data.R
+++ b/R/filter_sensitive_data.R
@@ -20,6 +20,10 @@ sensitive_put_back <- function(x) {
   return(x)
 }
 sensitive_remove <- function(x) {
+  if (is.null(x)) {
+    return()
+  }
+
   fsd <- vcr_c$filter_sensitive_data
   for (i in seq_along(fsd)) {
     if (nchar(fsd[[i]]) > 0) {

--- a/R/http_interaction_list.R
+++ b/R/http_interaction_list.R
@@ -172,24 +172,13 @@ HTTPInteractionList <- R6::R6Class(
 
     # return: interactions list
     interaction_matches_request = function(req, interaction) {
-      bod <- interaction$request$body
-      if (length(names(bod)) > 0) {
-        if ("string" %in% names(bod)) bod <- bod$string
-      }
-      intreq <- Request$new(
-        interaction$request$method,
-        interaction$request$uri,
-        bod,
-        interaction$request$headers
-      )
       vcr_log_sprintf(
         "  Checking if {%s} matches {%s} using matchers: [%s]",
         request_summary(req),
-        request_summary(intreq),
+        request_summary(interaction$request),
         paste0(self$request_matchers, collapse = ", ")
       )
-
-      request_matches(req, intreq, self$request_matchers)
+      request_matches(req, interaction$request, self$request_matchers)
     },
 
     # return: character

--- a/R/request_handler-crul.R
+++ b/R/request_handler-crul.R
@@ -14,7 +14,7 @@ RequestHandlerCrul <- R6::R6Class(
         Request$new(
           request$method,
           request$url$url %||% request$url,
-          take_body(request) %||% "",
+          take_body(request),
           request$headers
         )
       }

--- a/R/serialize-interaction.R
+++ b/R/serialize-interaction.R
@@ -39,7 +39,21 @@ encode_interaction <- function(x, preserve_bytes) {
 }
 
 decode_interaction <- function(x, preserve_bytes) {
-  x$request$body <- decode_body(x$request$body)
-  x$response$body <- decode_body(x$response$body, preserve_bytes)
-  x
+  request_body <- decode_body(x$request$body, preserve_bytes = preserve_bytes)
+  response_body <- decode_body(x$response$body, preserve_bytes = preserve_bytes)
+
+  list(
+    request = Request$new(
+      method = x$request$method,
+      uri = x$request$uri,
+      body = request_body$data,
+      headers = x$request$headers
+    ),
+    response = VcrResponse$new(
+      status = x$response$status,
+      headers = x$response$headers,
+      body = response_body$data,
+      disk = response_body$file
+    )
+  )
 }

--- a/tests/testthat/_snaps/serializer.md
+++ b/tests/testthat/_snaps/serializer.md
@@ -62,3 +62,4 @@
             string: body
         recorded_at: 2024-01-01 12:00:00 GMT
       recorded_with: <package_versions>
+

--- a/tests/testthat/_snaps/serializer.md
+++ b/tests/testthat/_snaps/serializer.md
@@ -6,6 +6,14 @@
       Error in `serializer_fetch()`:
       ! Unsupported cassette serializer "foo".
 
+# warns if you reload string with preserve_exact_body_bytes
+
+    Code
+      use_cassette("test", httr::GET(hb("/get")), preserve_exact_body_bytes = TRUE)
+    Condition
+      Warning in `decode_body()`:
+      re-record cassettes using 'preserve_exact_body_bytes = TRUE'
+
 # generates expected yaml
 
     Code
@@ -17,10 +25,7 @@
             "request": {
               "method": "get",
               "uri": "http://example.com",
-              "body": {
-                "encoding": "",
-                "string": ""
-              },
+              "body": {},
               "headers": []
             },
             "response": {
@@ -29,7 +34,6 @@
                 "name": "val"
               },
               "body": {
-                "encoding": "",
                 "string": "body"
               }
             },
@@ -48,17 +52,13 @@
       - request:
           method: get
           uri: http://example.com
-          body:
-            encoding: ''
-            string: ''
+          body: {}
           headers: []
         response:
           status: 200
           headers:
             name: val
           body:
-            encoding: ''
             string: body
         recorded_at: 2024-01-01 12:00:00 GMT
       recorded_with: <package_versions>
-

--- a/tests/testthat/test-ause_cassette_match_body_empty_body.R
+++ b/tests/testthat/test-ause_cassette_match_body_empty_body.R
@@ -34,7 +34,7 @@ test_that("use_cassette: match on body w/ empty body", {
 
   # the request body in the cassette is an empty string
   cas <- read_cassette("testing9.yml")
-  expect_equal(cas$http_interactions[[1]]$request$body$string, "")
+  expect_equal(cas$http_interactions[[1]]$request$body$string, NULL)
 
   # NOTE: internally, the NULL in the request body gets turned into
   # an empty string, so we end up comparing an empty string to an empty

--- a/tests/testthat/test-serializer.R
+++ b/tests/testthat/test-serializer.R
@@ -39,8 +39,7 @@ test_that("warns if you reload string with preserve_exact_body_bytes", {
   local_vcr_configure(dir = withr::local_tempdir())
 
   use_cassette("test", httr::GET(hb("/get")))
-
-  expect_warning(use_cassette(
+  expect_snapshot(use_cassette(
     "test",
     httr::GET(hb("/get")),
     preserve_exact_body_bytes = TRUE


### PR DESCRIPTION
* Move Request/Response object creation out of `cassette_class` and into `decode_interaction()`
* Consistently record empty bodies as `NULL`
* Drop unused encoding value
