### PR TITLE
Fix accidentally broken logging message

### DIFF
--- a/R/request_handler.R
+++ b/R/request_handler.R
@@ -47,9 +47,8 @@ RequestHandler <- R6::R6Class(
     #' @return handles a request, outcomes vary
     handle = function() {
       vcr_log_sprintf(
-        "Handling request: %s (%s)",
-        private$request_summary(self$request),
-        if (webmockr::enabled(adapter)) "enabled" else "disabled"
+        "Handling request: %s",
+        private$request_summary(self$request)
       )
 
       if (private$externally_stubbed()) {


### PR DESCRIPTION
My gut feeling that webmockr being unexpectedly disabled is not a frequent source of issues so we can just omit it from the log.
