### PR TITLE
Strip date header when comparing responses

### DIFF
--- a/tests/testthat/test-request_handler-httr2.R
+++ b/tests/testthat/test-request_handler-httr2.R
@@ -12,9 +12,15 @@ test_that("can generate all three types of response", {
   local_vcr_configure(ignore_localhost = TRUE)
   use_cassette("test", resp_ignore <- httr2::req_perform(req))
 
-  compare <- setdiff(names(resp_record), c("request", "cache", "url"))
-  expect_equal(resp_replay[compare], resp_record[compare])
-  expect_equal(resp_ignore[compare], resp_record[compare])
+  compare <- function(resp) {
+    resp$request <- NULL
+    resp$cache <- NULL
+    resp$url <- NULL
+    resp$headers["Date"] <- NULL
+    resp
+  }
+  expect_equal(compare(resp_replay), compare(resp_record))
+  expect_equal(compare(resp_ignore), compare(resp_record))
 })
 
 test_that("can capture & replay raw body", {


### PR DESCRIPTION
Fixes #394
