### PR TITLE
DESCRIPTION fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,6 +27,8 @@ URL: https://github.com/ropensci/vcr/,
     https://books.ropensci.org/http-testing/,
     https://docs.ropensci.org/vcr/
 BugReports: https://github.com/ropensci/vcr/issues
+Depends: 
+    R (>= 4.1)
 Imports:
     cli,
     crul (>= 0.8.4),
@@ -56,7 +58,6 @@ Config/testthat/parallel: true
 Config/testthat/start-first: ause_cassette_re_record
 Encoding: UTF-8
 Language: en-US
-LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 X-schema.org-applicationCategory: Web


### PR DESCRIPTION
* Now need R 4.1 (since we use the shorthand function syntax)
* No longer need `LazyData`
