### PR TITLE
Always store method  as upperclass

### DIFF
--- a/R/request_class.R
+++ b/R/request_class.R
@@ -5,7 +5,7 @@ vcr_request <- function(method, uri, body = NULL, headers = list()) {
 
   structure(
     list(
-      method = method,
+      method = toupper(method),
       uri = uri,
       body = body,
       headers = headers


### PR DESCRIPTION
This fixes the failing test, which must have come about as some non-trivial interaction between PRs.