### PR TITLE
Create `write_disk_path` only when needed

### DIFF
--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -167,9 +167,6 @@ Cassette <- R6::R6Class(
 
       # create new env for recorded interactions
       self$new_recorded_interactions <- list()
-
-      # check on write to disk path
-      if (!is.null(vcr_c$write_disk_path)) dir_create(vcr_c$write_disk_path)
     },
 
     #' @description ejects the cassette

--- a/R/request_handler-httr.R
+++ b/R/request_handler-httr.R
@@ -195,6 +195,7 @@ save_file <- function(path) {
       i = "See ?vcr_configure for details."
     ))
   }
+  dir_create(vcr_c$write_disk_path)
   out_path <- file.path(vcr_c$write_disk_path, basename(path))
 
   file.copy(path, out_path, overwrite = TRUE)


### PR DESCRIPTION
I think it's a bit more clear to create this in the (new) `save_file()`.