### PR TITLE
Minor httr handler refactoring

### DIFF
--- a/R/request_handler-httr.R
+++ b/R/request_handler-httr.R
@@ -24,9 +24,11 @@ RequestHandlerHttr <- R6::R6Class(
 
       # real request
       webmockr::httr_mock(FALSE)
-      on.exit(webmockr::httr_mock(TRUE), add = TRUE)
-      tmp2 <- eval(parse(text = paste0("httr::", self$request$method)))(
-        self$request$url,
+      withr::defer(webmockr::httr_mock(TRUE))
+
+      tmp2 <- httr::VERB(
+        verb = self$request$method,
+        url = self$request$url,
         body = curl_body(self$request),
         do.call(httr::config, self$request$options),
         httr::add_headers(self$request$headers)
@@ -38,7 +40,10 @@ RequestHandlerHttr <- R6::R6Class(
 
     on_stubbed_by_vcr_request = function() {
       # return stubbed vcr response - no real response to do
-      serialize_to_httr(self$request, super$get_stubbed_response(self$request))
+      serialize_to_httr(
+        self$request_original,
+        super$get_stubbed_response(self$request)
+      )
     },
 
     on_recordable_request = function() {
@@ -48,18 +53,21 @@ RequestHandlerHttr <- R6::R6Class(
 
       # real request
       webmockr::httr_mock(FALSE)
-      on.exit(webmockr::httr_mock(TRUE), add = TRUE)
-      tmp2 <- eval(parse(
-        text = paste0("httr::", self$request_original$method)
-      ))(
-        self$request_original$url,
+      withr::defer(webmockr::httr_mock(TRUE))
+
+      httr_response <- httr::VERB(
+        verb = self$request_original$method,
+        url = self$request_original$url,
         body = curl_body(self$request_original),
         do.call(httr::config, self$request_original$options),
         httr::add_headers(self$request_original$headers),
         if (!is.null(self$request_original$output$path))
           httr::write_disk(self$request_original$output$path, TRUE)
       )
-      response <- webmockr::build_httr_response(self$request_original, tmp2)
+      response <- webmockr::build_httr_response(
+        self$request_original,
+        httr_response
+      )
 
       body <- vcr_body(response$content, response$headers)
       vcr_response <- vcr_response(
@@ -98,66 +106,23 @@ vcr_body <- function(body, headers) {
 }
 
 # generate actual httr response
-serialize_to_httr <- function(request, response) {
-  # request
-  req <- webmockr::RequestSignature$new(
-    method = request$method,
-    uri = request$uri,
-    options = list(
-      body = request$body %||% NULL,
-      headers = request$headers %||% NULL,
-      proxies = NULL,
-      auth = NULL,
-      disk = response$disk,
-      fields = request$fields %||% NULL,
-      output = request$output %||% NULL
-    )
-  )
-
-  # response
+serialize_to_httr <- function(httr_request, vcr_response) {
   resp <- webmockr::Response$new()
-  resp$set_url(request$uri)
+  resp$set_url(httr_request$uri)
   # in vcr >= v0.4, "disk" is in the response, but in older versions
   # its missing - use response$body if disk is not present
-  response_body <- response$body
-  if (response$disk) {
-    response_body <- structure(response$body, class = "path")
+  response_body <- vcr_response$body
+  if (vcr_response$disk) {
+    response_body <- structure(vcr_response$body, class = "path")
   }
-  resp$set_body(response_body, response$disk)
-  resp$set_request_headers(request$headers, capitalize = FALSE)
-  resp$set_response_headers(response$headers, capitalize = FALSE)
-  resp$set_status(status = response$status)
+  resp$set_body(response_body, vcr_response$disk)
+  resp$set_request_headers(httr_request$headers, capitalize = FALSE)
+  resp$set_response_headers(vcr_response$headers, capitalize = FALSE)
+  resp$set_status(status = vcr_response$status)
 
   # generate httr response
-  webmockr::build_httr_response(as_httr_request(req), resp)
+  webmockr::build_httr_response(httr_request, resp)
 }
-
-keep_last <- function(...) {
-  x <- c(...)
-  x[!duplicated(names(x), fromLast = TRUE)]
-}
-httr_ops <- function(method, w) {
-  # if (!length(w)) return(w)
-  if (tolower(method) == "get") w$httpget <- TRUE
-  if (tolower(method) == "post") w$post <- TRUE
-  if (!tolower(method) %in% c("get", "post")) w$customrequest <- toupper(method)
-  return(w)
-}
-as_httr_request <- function(x) {
-  structure(
-    list(
-      method = toupper(x$method),
-      url = x$url$url,
-      headers = keep_last(x$headers),
-      fields = x$fields,
-      options = httr_ops(x$method, compact(keep_last(x$options))),
-      auth_token = x$auth,
-      output = x$output
-    ),
-    class = "request"
-  )
-}
-
 
 curl_body <- function(x) {
   no_post <- (is.null(x$options$postfieldsize) || x$options$postfieldsize == 0L)
@@ -181,11 +146,6 @@ curl_body <- function(x) {
     cli::cli_abort("couldn't fetch request body; please file an issue")
   }
   if (inherits(tmp, "raw")) rawToChar(tmp) else tmp
-}
-
-is_body_empty <- function(x) {
-  is.null(x$fields) &&
-    (is.null(x$options$postfieldsize) || x$options$postfieldsize == 0L)
 }
 
 save_file <- function(path) {

--- a/tests/testthat/test-request_handler-httr.R
+++ b/tests/testthat/test-request_handler-httr.R
@@ -68,7 +68,6 @@ test_that("httr use_cassette works", {
   expect_named(x2$request$headers, "Accept")
   expect_null(x2$request$fields)
   expect_true(x2$request$options$httpget)
-  expect_null(x2$request$output) # can't really populate this from cassette
 
   # response
   expect_s3_class(x, "response")


### PR DESCRIPTION
* Use `httr::VERB()`
* Use `with::defer()`
* Improve variable name
* Use original httr request when recreating response
