### PR TITLE
Automatically compress raw bodies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ vcr (development version)
 
 ## NEW FEATURES
 
+* Raw bodies are now automatically gzipped before being converted to base64 (#343).
 * The default path is now `tests/testthat/_vcr`. This should not affect existing packages that used `use_vcr()` because these set up a helper that sets the default directory with `vcr_configure()` (#395).
 * `local_vcr_configure()` allows you to temporarily affect vcr configuration.
 

--- a/R/serialize-body.R
+++ b/R/serialize-body.R
@@ -1,4 +1,4 @@
-encode_body <- function(body, file, preserve_bytes = FALSE) {
+encode_body <- function(body, file = FALSE, preserve_bytes = FALSE) {
   if (isTRUE(file)) {
     list(on_disk = body)
   } else {
@@ -6,10 +6,11 @@ encode_body <- function(body, file, preserve_bytes = FALSE) {
       set_names(list())
     } else if (is.list(body)) {
       list(fields = body)
-    } else if (is.raw(body) || preserve_bytes) {
-      list(base64_string = to_base64(body))
-    } else if (is_string(body)) {
+    } else if (is_string(body) && !preserve_bytes) {
       list(string = encode_sensitive(body))
+    } else if (is.raw(body) || preserve_bytes) {
+      data <- memCompress(body, type = "gzip")
+      list(raw_gzip = to_base64(data))
     } else {
       cli::cli_abort("Unsupported body type", .internal = TRUE)
     }
@@ -21,16 +22,27 @@ decode_body <- function(body, preserve_bytes = FALSE) {
     warning("re-record cassettes using 'preserve_exact_body_bytes = TRUE'")
   }
 
-  if (has_name(body, "fields")) {
-    list(data = body$fields, on_disk = FALSE)
-  } else if (has_name(body, "on_disk")) {
+  if (has_name(body, "on_disk")) {
     list(data = body$on_disk, on_disk = TRUE)
-  } else if (has_name(body, "base64_string")) {
-    list(data = from_base64(body$base64_string), on_disk = FALSE)
-  } else {
+  } else if (isTRUE(body$file)) {
     # In v1, on_disk bodies were recorded with `file = TRUE` and
     # a `string` body giving the path.
+    list(data = body$string, on_disk = TRUE)
+  } else if (has_name(body, "string")) {
     list(data = decode_sensitive(body$string), on_disk = FALSE)
+  } else if (length(body) == 0) {
+    list(data = NULL, on_disk = FALSE)
+  } else if (has_name(body, "fields")) {
+    list(data = body$fields, on_disk = FALSE)
+  } else if (has_name(body, "raw_gzip")) {
+    data <- from_base64(body$raw_gzip)
+    data <- memDecompress(data, type = "gzip")
+    list(data = data, on_disk = FALSE)
+  } else if (has_name(body, "base64_string")) {
+    # In v1, raw bodies were recorded in `base64_string`
+    list(data = from_base64(body$base64_string), on_disk = FALSE)
+  } else {
+    cli::cli_abort("Unsupported body type", .internal = TRUE)
   }
 }
 
@@ -42,10 +54,6 @@ from_base64 <- function(x) {
 }
 
 to_base64 <- function(x) {
-  if (is.null(x)) {
-    return(NULL)
-  }
-
   x <- jsonlite::base64_enc(x)
 
   # Split into lines of 80 characters

--- a/tests/testthat/test-request_handler-httr.R
+++ b/tests/testthat/test-request_handler-httr.R
@@ -258,7 +258,7 @@ test_that("binary body uses bsae64 encoding", {
     httr::GET(hb("/image"), httr::add_headers("Accept" = "image/png"))
   )
   interaction <- read_cassette("test.yml")$http_interactions[[1]]
-  expect_named(interaction$response$body, "base64_string")
+  expect_named(interaction$response$body, "raw_gzip")
 })
 
 test_that("can write files to disk", {

--- a/tests/testthat/test-request_handler-httr2.R
+++ b/tests/testthat/test-request_handler-httr2.R
@@ -144,7 +144,7 @@ test_that("binary body uses base64 encoding", {
 
   use_cassette("test", httr2::req_perform(req))
   interaction <- read_cassette("test.yml")$http_interactions[[1]]
-  expect_named(interaction$response$body, "base64_string")
+  expect_named(interaction$response$body, "raw_gzip")
 })
 
 test_that("can capture body: json", {

--- a/tests/testthat/test-serialize-body.R
+++ b/tests/testthat/test-serialize-body.R
@@ -8,3 +8,26 @@ test_that("to_base64 and from_base64 are idempotent", {
   string <- strrep("x", 1000)
   expect_equal(from_base64(to_base64(string)), charToRaw(string))
 })
+
+test_that("encode_body and decode_body are idempotent", {
+  test_idempotent <- function(data) {
+    expect_equal(decode_body(encode_body(data))$data, data)
+  }
+
+  test_idempotent(NULL)
+  test_idempotent(list(a = 1, b = 2))
+  test_idempotent("abcdefg")
+  test_idempotent(charToRaw("abcdefg"))
+})
+
+test_that("can decode v1 bodies", {
+  expect_equal(
+    decode_body(list(string = "foo.txt", file = TRUE)),
+    list(data = "foo.txt", on_disk = TRUE)
+  )
+
+  expect_equal(
+    decode_body(list(base64_string = "YWJjZGVm")),
+    list(data = charToRaw("abcdef"), on_disk = FALSE)
+  )
+})

--- a/tests/testthat/test-serializer.R
+++ b/tests/testthat/test-serializer.R
@@ -213,9 +213,8 @@ test_that("JSON usage", {
   )
   expect_s3_class(raf, "HttpResponse")
   expect_s3_class(raz, "HttpResponse")
-  expect_length(jsonlite::fromJSON(dd$file(), FALSE)[[1]], 2)
-  bodies <- jsonlite::fromJSON(dd$file())[[1]]$response$body$string
-  for (i in bodies) expect_true(is_base64(i))
+  expect_length(jsonlite::read_json(dd$file())[[1]], 2)
+  expect_named(jsonlite::fromJSON(dd$file())[[1]]$response$body, "raw_gzip")
 })
 
 # YAML -------------------------------------------------------------------------


### PR DESCRIPTION
Introduces a new body type called "raw_gzip", ensuring that we have room to introduce new compression types in the future.

I also added more tests for body decoding/encoding so that this code is tested more directly, rather than only relying on end-to-end tests.

Fixes #343
