### PR TITLE
Only create cassette directory when writing vignette

### DIFF
--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -139,8 +139,6 @@ Cassette <- R6::R6Class(
     #' @description insert the cassette
     #' @return self
     insert = function() {
-      dir_create(self$root_dir)
-
       if (!file.exists(self$file())) {
         self$new_cassette <- TRUE
         interactions <- list()
@@ -279,6 +277,8 @@ Cassette <- R6::R6Class(
 
       self$new_interactions <- TRUE
       self$http_interactions$add(request, response)
+
+      dir_create(self$root_dir)
       self$serializer$serialize(self$http_interactions$interactions)
     }
   )


### PR DESCRIPTION
This avoids creating in the vcr tests themselves.
