### PR TITLE
Show simple error if logging turned on

### DIFF
--- a/R/request_handler.R
+++ b/R/request_handler.R
@@ -53,8 +53,13 @@ RequestHandler <- R6::R6Class(
         return(private$on_recordable_request())
       }
 
-      err <- UnhandledHTTPRequestError$new(self$request)
-      err$run()
+      if (the$config$log) {
+        # Log messages already give the details
+        cli::cli_abort("Failed to find matching request in active cassette.")
+      } else {
+        err <- UnhandledHTTPRequestError$new(self$request)
+        err$run()
+      }
     }
   ),
 

--- a/tests/testthat/_snaps/cassette_class.md
+++ b/tests/testthat/_snaps/cassette_class.md
@@ -42,7 +42,7 @@
       [Cassette: test]   Replaying response 1
       [Cassette: test] Ejecting
     Code
-      try(use_cassette("test", httr::GET(hb("/404"))), silent = TRUE)
+      use_cassette("test", httr::GET(hb("/404")))
     Output
       [Cassette: test] Inserting 'test.yml' (with 1 interactions)
       [Cassette: test]   recording: FALSE
@@ -52,5 +52,7 @@
       [Cassette: test]     `matching$uri$path`: "/404" 
       [Cassette: test]     `recorded$uri$path`: "/html"
       [Cassette: test]   No matching requests
-      [Cassette: test] Ejecting
+    Condition
+      Error:
+      ! Failed to find matching request in active cassette.
 

--- a/tests/testthat/test-cassette_class.R
+++ b/tests/testthat/test-cassette_class.R
@@ -45,8 +45,11 @@ test_that("important interactions are logged", {
     {
       use_cassette("test", httr::GET(hb("/html")))
       use_cassette("test", httr::GET(hb("/html")))
-      try(use_cassette("test", httr::GET(hb("/404"))), silent = TRUE)
+      # Fails to capture ejecting message due to
+      # https://github.com/r-lib/testthat/issues/2081
+      use_cassette("test", httr::GET(hb("/404")))
     },
+    error = TRUE,
     transform = \(x) gsub(hb(), "{httpbin}", x, fixed = TRUE),
   )
 })


### PR DESCRIPTION
I don't think there's a need for additional details since you see it all during the matching process.
