### PR TITLE
Use `check_` helpers every where

### DIFF
--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -108,7 +108,7 @@ Cassette <- R6::R6Class(
         the$config$re_record_interval
       self$allow_playback_repeats = allow_playback_repeats
 
-      assert(preserve_exact_body_bytes, "logical")
+      check_bool(preserve_exact_body_bytes, allow_null = TRUE)
       self$preserve_exact_body_bytes <- preserve_exact_body_bytes %||%
         the$config$preserve_exact_body_bytes
 

--- a/R/check_cassette_names.R
+++ b/R/check_cassette_names.R
@@ -24,7 +24,7 @@ check_cassette_names <- function(
 ) {
   lifecycle::deprecate_warn("2.0.0", "check_cassette_names()")
 
-  assert(allowed_duplicates, "character")
+  check_character(allowed_duplicates, allow_null = TRUE)
   files <- list.files(".", pattern = pattern, full.names = TRUE)
   if (length(files) == 0) return(invisible())
   cassette_names <- function(x) {

--- a/R/request_response.R
+++ b/R/request_response.R
@@ -1,5 +1,7 @@
 request_summary <- function(request, request_matchers = "") {
-  stopifnot(inherits(request_matchers, "character"))
+  check_vcr_request(request)
+  check_character(request_matchers)
+
   atts <- c(request$method, request$uri)
   if ("body" %in% request_matchers) {
     atts <- c(atts, substring(request$body, 0, 80))
@@ -11,7 +13,7 @@ request_summary <- function(request, request_matchers = "") {
 }
 
 response_summary <- function(response) {
-  stopifnot(inherits(response, "vcr_response"))
+  check_vcr_response(response)
 
   # if body is raw, state that it's raw
   if (is.null(response$body)) {

--- a/R/serialize-uri.R
+++ b/R/serialize-uri.R
@@ -36,8 +36,8 @@ decode_uri <- function(uri, filter = the$config$filter_query_parameters) {
 # drop_param(url="https://hb.opencpu.org/get?foo=bar&baz=3&z=4", name="z")
 # => "https://hb.opencpu.org/get?foo=bar&baz=3"
 drop_param <- function(url, name) {
-  assert(name, "character")
-  stopifnot("can only drop one name at a time" = length(name) == 1)
+  check_string(name)
+
   z <- parseurl(url)
   if (!is.list(z$parameter)) return(url)
   z$parameter[[name]] <- NULL
@@ -52,8 +52,8 @@ drop_param <- function(url, name) {
 # replace_param(url="https://hb.opencpu.org/get", name="foo", value=4)
 # => "https://hb.opencpu.org/get"
 replace_param <- function(url, name, value) {
-  assert(name, "character")
-  stopifnot("can only replace one name at a time" = length(name) == 1)
+  check_string(name)
+
   z <- parseurl(url)
   if (!is.list(z$parameter)) return(url)
   if (is.null(z$parameter[[name]])) return(url)
@@ -62,8 +62,8 @@ replace_param <- function(url, name, value) {
 }
 
 replace_param_with <- function(url, name, fake, real) {
-  assert(name, "character")
-  stopifnot("can only replace one name at a time" = length(name) == 1)
+  check_string(name)
+
   z <- parseurl(url)
   if (!is.list(z$parameter)) return(url)
   if (is.null(z$parameter[[name]])) return(url)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,19 +1,5 @@
 compact <- function(x) Filter(Negate(is.null), x)
 
-assert <- function(x, y) {
-  if (!is.null(x)) {
-    if (!inherits(x, y)) {
-      stop(
-        deparse(substitute(x)),
-        " must be of class ",
-        paste0(y, collapse = ", "),
-        call. = FALSE
-      )
-    }
-  }
-  invisible(x)
-}
-
 check_request_matchers <- function(
   x,
   error_arg = caller_arg(x),

--- a/R/vcr_setup.R
+++ b/R/vcr_setup.R
@@ -85,8 +85,7 @@ test_r_file_exists <- function(dir) {
 use_vcr <- function(dir = ".", verbose = TRUE) {
   lifecycle::deprecate_warn("2.0.0", "vcr::use_vcr()")
 
-  assert(dir, "character")
-  stopifnot(length(dir) == 1)
+  check_string(dir)
   if (!dir.exists(dir)) stop("'dir' does not exist")
   check_installed(c("desc", "cli", "crayon"))
 

--- a/tests/testthat/_snaps/use_cassette.md
+++ b/tests/testthat/_snaps/use_cassette.md
@@ -19,8 +19,8 @@
     Code
       local_cassette("text", NULL, preserve_exact_body_bytes = "xxx")
     Condition
-      Error:
-      ! preserve_exact_body_bytes must be of class logical
+      Error in `initialize()`:
+      ! `preserve_exact_body_bytes` must be `TRUE`, `FALSE`, or `NULL`, not the string "xxx".
     Code
       local_cassette("test", NULL, serialize_with = "howdy")
     Condition

--- a/tests/testthat/_snaps/vcr_setup.md
+++ b/tests/testthat/_snaps/vcr_setup.md
@@ -6,3 +6,11 @@
       Warning:
       `use_vcr()` was deprecated in vcr 2.0.0.
 
+# use_vcr fails well
+
+    Code
+      use_vcr(5)
+    Condition
+      Error in `use_vcr()`:
+      ! `dir` must be a single string, not the number 5.
+

--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -37,19 +37,6 @@ recorded_at <- function(x) {
   yaml::yaml.load_file(x$file())$http_interactions[[1]]$recorded_at
 }
 
-extract_vcr_config_args <- function(rdfile) {
-  stopifnot(file.exists(rdfile))
-
-  rdtext <- paste0(readLines(rdfile), collapse = "")
-  rdhits <- gregexpr("item \\\\code\\{([a-z_]+)\\}", rdtext, perl = TRUE)[[1]]
-
-  substring(
-    rdtext,
-    attr(rdhits, "capture.start"),
-    attr(rdhits, "capture.start") + attr(rdhits, "capture.length") - 1
-  )
-}
-
 check_url <- function(x, ...) {
   suppressWarnings(suppressMessages(crul::ok(x, ...)))
 }

--- a/tests/testthat/test-vcr_setup.R
+++ b/tests/testthat/test-vcr_setup.R
@@ -31,8 +31,7 @@ test_that("use_vcr works", {
 test_that("use_vcr fails well", {
   withr::local_options(lifecycle_verbosity = "quiet")
 
-  expect_error(use_vcr(5), "dir must be of class character")
-  expect_error(use_vcr(letters[1:2]), "length\\(dir\\) == 1 is not TRUE")
+  expect_snapshot(use_vcr(5), error = TRUE)
 
   # dir does not exist
   dir <- "doesnt_exist"


### PR DESCRIPTION
This eliminates all remaining uses of `assert()` and `stopifnot()`
