### PR TITLE
Drop unused `cassette_has_respose()`

### DIFF
--- a/R/interactions.R
+++ b/R/interactions.R
@@ -56,11 +56,6 @@ Interactions <- R6::R6Class(
       self$interactions[[i]]$response
     },
 
-    has_interaction = function(request) {
-      idx <- self$find_request(request)
-      !is.na(idx)
-    },
-
     has_used_interaction = function(request) {
       idx <- self$find_request(request, allow_playback = TRUE)
       !is.na(idx) && !self$replayable[[idx]]

--- a/R/request_handler.R
+++ b/R/request_handler.R
@@ -120,11 +120,3 @@ casette_is_replayable <- function() {
     FALSE
   }
 }
-
-cassette_has_response <- function(request) {
-  if (cassette_active()) {
-    current_cassette()$http_interactions$has_interaction(request)
-  } else {
-    FALSE
-  }
-}

--- a/tests/testthat/test-interactions.R
+++ b/tests/testthat/test-interactions.R
@@ -10,7 +10,6 @@ test_that("can find matching interations", {
 
   expect_equal(interactions$find_request(req1), 1)
   expect_equal(interactions$find_request(req2), 2)
-  expect_equal(interactions$has_interaction(req2), TRUE)
   expect_equal(interactions$has_used_interaction(req1), FALSE)
 })
 
@@ -26,7 +25,6 @@ test_that("handles non-matches", {
   ))
   req3 <- vcr_request("GET", "http://c.com")
 
-  expect_false(interactions$has_interaction(req3))
   expect_false(interactions$has_used_interaction(req3))
   expect_equal(interactions$find_request(req3), NA_integer_)
 })


### PR DESCRIPTION
And corresponding `$has_interaction()` method. I didn't notice I eliminated the need for this code in #425, where I refactored the code flow so that we only ever look up an interaction once (instead of twice as before).
