### PR TITLE
Eliminate private `RequestHandler` methods

### DIFF
--- a/R/request_handler-crul.R
+++ b/R/request_handler-crul.R
@@ -13,9 +13,7 @@ RequestHandlerCrul <- R6::R6Class(
         curl_body(request),
         as.list(fake_resp$request_headers)
       )
-    }
-  ),
-  private = list(
+    },
     on_ignored_request = function() {
       tmp2 <- webmockr::webmockr_crul_fetch(self$request_original)
       response <- webmockr::build_crul_response(self$request_original, tmp2)

--- a/R/request_handler-httr.R
+++ b/R/request_handler-httr.R
@@ -12,10 +12,7 @@ RequestHandlerHttr <- R6::R6Class(
         curl_body(request),
         as.list(request$headers)
       )
-    }
-  ),
-
-  private = list(
+    },
     on_ignored_request = function() {
       webmockr::httr_mock(FALSE)
       withr::defer(webmockr::httr_mock(TRUE))

--- a/R/request_handler-httr2.R
+++ b/R/request_handler-httr2.R
@@ -15,10 +15,7 @@ RequestHandlerHttr2 <- R6::R6Class(
         httr2_body(request),
         request$headers
       )
-    }
-  ),
-
-  private = list(
+    },
     on_ignored_request = function() {
       httr2::local_mocked_responses(NULL)
       httr2::req_perform(self$request_original)

--- a/man/RequestHandler.Rd
+++ b/man/RequestHandler.Rd
@@ -8,5 +8,6 @@
 \title{Request handlers}
 \description{
 These are internal classes that should not be used by users.
+They are exported because they are used from \pkg{webmockr}.
 }
 \keyword{internal}


### PR DESCRIPTION
This is not really a user facing class, so I don't think it's necessary to distinguish between public and private, and thus it's simpler to make everything public. I also removed some out dated docs, and removed the now unused `get_stubbed_response()` method.
