### PR TITLE
Fixes for dev httr2

### DIFF
--- a/R/request_handler-httr2.R
+++ b/R/request_handler-httr2.R
@@ -72,8 +72,8 @@ RequestHandlerHttr2 <- R6::R6Class(
 
 httr2_body <- function(x) {
   if (modern_httr2()) {
-    type <- httr2::req_get_body_type(x)
-    data <- httr2::req_get_body(x)
+    type <- getNamespace("httr2")$req_get_body_type(x)
+    data <- getNamespace("httr2")$req_get_body(x)
   } else {
     type <- x$body$type %||% "empty"
     data <- x$body$data

--- a/R/serialize-headers.R
+++ b/R/serialize-headers.R
@@ -45,12 +45,16 @@ headers_remove <- function(headers, filter) {
 }
 
 request_headers_redact <- function(headers) {
+  # TODO: remove once we depend on modern httr2
   to_redact <- union(attr(headers, "redact"), "authorization")
   matches <- match(tolower(to_redact), tolower(names(headers)))
   matches <- matches[!is.na(matches)]
 
-  headers[matches] <- "<redacted>"
-  headers
+  if (length(matches) == 0) {
+    headers
+  } else {
+    headers[-matches]
+  }
 }
 
 # dedup header keys so we have unique yaml keys
@@ -59,7 +63,9 @@ request_headers_redact <- function(headers) {
 # (x <- list(b = "foo", a = 5, a = 6))
 # dedup_keys(x)
 dedup_keys <- function(x) {
-  if (length(x) == 0 || is.null(x)) return(x)
+  if (length(x) == 0 || is.null(x)) {
+    return(x)
+  }
   nms <- names(x)
   # if repeats, collapse dups under single name
   if (length(unique(nms)) != length(nms)) {

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -187,7 +187,13 @@ use_cassette <- function(
   )
 
   # force all arguments
-  list(...)
+  withCallingHandlers(
+    list(...),
+    error = function(cnd) {
+      # Don't warn if there was also an error
+      cassette$warn_on_empty <- FALSE
+    }
+  )
 
   invisible(cassette)
 }
@@ -258,11 +264,12 @@ check_cassette_name <- function(x, call = caller_env()) {
   reserved <- "^[.]+$"
   windows_reserved <- "^(con|prn|aux|nul|com[0-9]|lpt[0-9])([.].*)?$"
   windows_trailing <- "[. ]+$"
-  if (grepl(illegal, x))
+  if (grepl(illegal, x)) {
     cli::cli_abort(
       "{.arg name} must not contain '/', '?', '<', '>', '\\', ':', '*', '|', or '\"'",
       call = call
     )
+  }
   if (grepl(control, x)) {
     cli::cli_abort(
       "{.arg name} must not contain control characters.",

--- a/tests/testthat/test-request_handler-httr2.R
+++ b/tests/testthat/test-request_handler-httr2.R
@@ -154,7 +154,7 @@ test_that("httr2 redacts auth header", {
   request <- httr2::request(hb("/basic-auth/foo/bar"))
   request <- httr2::req_auth_basic(request, "foo", "bar")
   use_cassette("test", response <- httr2::req_perform(request))
-  expect_equal(vcr_last_request()$headers, list(Authorization = "<redacted>"))
+  expect_equal(vcr_last_request()$headers, set_names(list()))
 })
 
 test_that("can capture body: string", {
@@ -267,8 +267,5 @@ test_that("redacted headers handled appropriately", {
       httr2::req_perform()
   })
 
-  expect_equal(
-    vcr_last_request()$headers,
-    list(NotASecret = "NotHidden", SecretHeader = "<redacted>")
-  )
+  expect_equal(vcr_last_request()$headers, list(NotASecret = "NotHidden"))
 })

--- a/tests/testthat/test-request_handler-httr2.R
+++ b/tests/testthat/test-request_handler-httr2.R
@@ -19,6 +19,7 @@ test_that("can generate all three types of response", {
     resp$cache <- NULL
     resp$url <- NULL
     resp$headers["Date"] <- NULL
+    resp$timing <- NULL
     resp
   }
   expect_equal(compare(resp_replay), compare(resp_record))

--- a/tests/testthat/test-serialize-headers.R
+++ b/tests/testthat/test-serialize-headers.R
@@ -115,13 +115,13 @@ test_that("dedup_keys", {
 test_that("Authorization is always redacted", {
   expect_equal(
     encode_headers(list(Authorization = "mysecret")),
-    list(Authorization = "<redacted>")
+    set_names(list())
   )
 
   # And it's case insensitive
   expect_equal(
     encode_headers(list(AUTHORIZATION = "mysecret")),
-    list(AUTHORIZATION = "<redacted>")
+    set_names(list())
   )
 })
 


### PR DESCRIPTION
This reveals:

* We need `req_get_headers()` that can redact/not
* `req_get_body()` needs to be reproducible for multipart

Will work on that in httr2 shortly