### PR TITLE
Match linguist regex

### DIFF
--- a/R/serialize-interaction.R
+++ b/R/serialize-interaction.R
@@ -13,7 +13,9 @@ encode_interactions <- function(
   )
   list(
     http_interactions = interactions,
-    recorded_with = pkg_versions()
+    # Include VCR so linguist recognises as a generated file
+    # https://github.com/github-linguist/linguist/blob/main/lib/linguist/generated.rb#L564-L569
+    recorded_with = paste0("VCR-", pkg_versions())
   )
 }
 
@@ -55,10 +57,12 @@ encode_request <- function(
   compact(list(
     method = request$method,
     uri = encode_uri(request$uri),
-    body = if ("body" %in% matchers || "body_json" %in% matchers)
-      encode_body(request$body, NULL, preserve_bytes),
-    headers = if ("headers" %in% matchers)
+    body = if ("body" %in% matchers || "body_json" %in% matchers) {
+      encode_body(request$body, NULL, preserve_bytes)
+    },
+    headers = if ("headers" %in% matchers) {
       encode_headers(request$headers, "request")
+    }
   ))
 }
 

--- a/tests/testthat/_snaps/serializer.md
+++ b/tests/testthat/_snaps/serializer.md
@@ -30,7 +30,7 @@
             "recorded_at": "2024-01-01 12:00:00"
           }
         ],
-        "recorded_with": "<package_versions>"
+        "recorded_with": "VCR-<package_versions>"
       }
 
 # generates expected yaml
@@ -49,5 +49,5 @@
           body:
             string: body
         recorded_at: 2024-01-01 12:00:00
-      recorded_with: <package_versions>
+      recorded_with: VCR-<package_versions>
 

--- a/tests/testthat/_vcr/integration.yml
+++ b/tests/testthat/_vcr/integration.yml
@@ -1,0 +1,28 @@
+http_interactions:
+- request:
+    method: GET
+    uri: http://127.0.0.1:51778/get
+  response:
+    status: 200
+    headers:
+      Connection: close
+      Date: Thu, 26 Jun 2025 13:27:20 GMT
+      Content-Type: application/json
+      Content-Length: '270'
+      ETag: '"b9f30070"'
+    body:
+      string: |-
+        {
+          "args": {},
+          "headers": {
+            "Host": "127.0.0.1:51778",
+            "User-Agent": "httr2/1.1.2 r-curl/6.4.0 libcurl/8.14.1",
+            "Accept": "*/*",
+            "Accept-Encoding": "deflate, gzip"
+          },
+          "origin": "127.0.0.1",
+          "path": "/get",
+          "url": "http://127.0.0.1:51778/get"
+        }
+  recorded_at: 2025-06-26 13:27:20
+recorded_with: VCR-vcr/1.7.0.91, webmockr/2.0.0.91

--- a/tests/testthat/test-use_cassette.R
+++ b/tests/testthat/test-use_cassette.R
@@ -1,3 +1,12 @@
+test_that("local_cassette() integration test", {
+  # This tests that everything works together AND ensures that we have
+  # one cassette file on disk
+  local_cassette("integration")
+
+  req <- httr2::request(hb("/get"))
+  expect_no_error(httr2::req_perform(req))
+})
+
 test_that("use_cassette returns a cassette", {
   cassette <- use_cassette("testing1", NULL, warn_on_empty = FALSE)
   expect_s3_class(cassette, "Cassette")


### PR DESCRIPTION
So that cassettes appear as generated files in GitHub PR diffs. This means that they're not shown by default, but can be expanded if desired.
