### PR TITLE
Set/reset env vars when inserting/ejecting

### DIFF
--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -114,6 +114,11 @@ Cassette <- R6::R6Class(
       )
       self$remove_outdated_interactions()
 
+      private$old_env_var <- set_env_var(list(
+        VCR_IS_RECORDING = self$recording(),
+        VCR_IS_REPLAYING = self$replaying()
+      ))
+
       if (self$recording() && self$replaying()) {
         vcr_log_sprintf("  Mode: recording and replaying")
       } else if (self$recording()) {
@@ -129,6 +134,8 @@ Cassette <- R6::R6Class(
     #' @return self
     eject = function() {
       vcr_log_sprintf("Ejecting")
+
+      set_env_var(private$old_env_var)
 
       if (self$http_interactions$length() == 0 && self$warn_on_empty) {
         cli::cli_warn(c(
@@ -215,5 +222,8 @@ Cassette <- R6::R6Class(
       dir_create(self$root_dir)
       self$serializer$serialize(self$http_interactions$interactions)
     }
+  ),
+  private = list(
+    old_env_var = character()
   )
 )

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -235,11 +235,6 @@ local_cassette <- function(
     warn_on_empty = warn_on_empty
   )
   if (!is.null(cassette)) {
-    withr::local_envvar(
-      VCR_IS_RECORDING = cassette$recording(),
-      VCR_IS_REPLAYING = cassette$replaying(),
-      .local_envir = frame
-    )
     withr::defer(eject_cassette(), envir = frame)
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,3 +93,19 @@ parse_http_date <- function(x) {
 cat_line <- function(...) {
   cat(paste0(..., "\n", collapse = ""))
 }
+
+set_env_var <- function(values) {
+  check_list(values)
+  old <- as.list(Sys.getenv(names(values), unset = NA, names = TRUE))
+
+  for (nm in names(values)) {
+    val <- values[[nm]]
+    if (is.na(val)) {
+      Sys.unsetenv(nm)
+    } else {
+      exec(Sys.setenv, !!!set_names(list(val), nm))
+    }
+  }
+
+  invisible(old)
+}

--- a/tests/testthat/test-cassette_class.R
+++ b/tests/testthat/test-cassette_class.R
@@ -51,3 +51,16 @@ test_that("important interactions are logged", {
     transform = \(x) gsub(hb(), "{httpbin}", x, fixed = TRUE),
   )
 })
+
+test_that("inserting and ejecting updates env vars", {
+  local_vcr_configure(dir = withr::local_tempdir())
+
+  cl <- Cassette$new("test", warn_on_empty = FALSE)
+  expect_false(is_recording())
+
+  cl$insert()
+  expect_true(is_recording())
+
+  cl$eject()
+  expect_false(is_recording())
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -2,3 +2,15 @@ test_that("pkg_versions", {
   expect_match(pkg_versions(), "vcr/")
   expect_match(pkg_versions(), "webmockr/")
 })
+
+test_that("can set env vars", {
+  withr::local_envvar(x1 = "a")
+
+  old <- set_env_var(list(x1 = "b"))
+  expect_equal(old, list(x1 = "a"))
+  expect_equal(Sys.getenv("x1"), "b")
+
+  old <- set_env_var(list(x1 = NA))
+  expect_equal(old, list(x1 = "b"))
+  expect_equal(Sys.getenv("x2", unset = NA), NA_character_)
+})


### PR DESCRIPTION
So the env vars are also set in vignettes and examples
