### PR TITLE
Use body/body_json by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@ vcr (development version)
 
 ## NEW FEATURES
 
+* The default request matcher now uses method, uri, and body if present.
 * `local_casette()` and `use_cassette()` set env vars `VCR_IS_RECORDING` and `VCR_IS_REPLAYING` and provide helpers `is_recording()` and `is_replaying()`. 
 * New `current_cassette_recording()` and `current_cassette_replaying()` tell you if the current cassette is recording or replaying (or neither or both).
 * New `vcr_last_request()` and `vcr_last_response()` to get last request and response respectively (#488).

--- a/R/cassette_class.R
+++ b/R/cassette_class.R
@@ -17,8 +17,7 @@ Cassette <- R6::R6Class(
     #' @field serializer (Serializer) serializer (YAML|JSON|QS2)
     serializer = NA,
     #' @field match_requests_on (character) matchers to use
-    #' default: method & uri
-    match_requests_on = c("method", "uri"),
+    match_requests_on = "default",
     #' @field re_record_interval (numeric) the re-record interval
     re_record_interval = NULL,
     #' @field root_dir root dir, gathered from [vcr_configuration()]
@@ -42,11 +41,7 @@ Cassette <- R6::R6Class(
     #' @param record The record mode. Default: "once".
     #' @param serialize_with (character) Which serializer to use.
     #' Valid values are "yaml" (default), "json", and "qs2".
-    #' @param match_requests_on List of request matchers
-    #' to use to determine what recorded HTTP interaction to replay. Defaults to
-    #' `["method", "uri"]`. The built-in matchers are "method", "uri",
-    #' "headers" and "body" ("host" and "path" not supported yet, but should
-    #' be in a future version)
+    #' @param match_requests_on HTTP request components to use when matching.
     #' @param re_record_interval (numeric) When given, the cassette will be
     #' re-recorded at the given interval, in seconds.
     #' @param preserve_exact_body_bytes (logical) Whether or not

--- a/R/configuration.R
+++ b/R/configuration.R
@@ -221,7 +221,7 @@ vcr_config_defaults <- function() {
   list(
     dir = NULL,
     record = "once",
-    match_requests_on = c("method", "uri"),
+    match_requests_on = "default",
     serialize_with = "yaml",
     json_pretty = FALSE,
     ignore_hosts = NULL,

--- a/R/request_handler.R
+++ b/R/request_handler.R
@@ -18,6 +18,9 @@ RequestHandler <- R6::R6Class(
 
     handle = function() {
       matchers <- current_cassette()$match_requests_on
+      if (identical(matchers, "default")) {
+        matchers <- default_matcher(self$request)
+      }
       summary <- request_summary(self$request, matchers)
       vcr_log_sprintf("Handling request: %s", summary)
 
@@ -27,12 +30,13 @@ RequestHandler <- R6::R6Class(
       }
 
       if (current_cassette_replaying()) {
-        cassette <- current_cassette()
-        interactions <- cassette$http_interactions
         vcr_log_sprintf(
           "  Looking for existing requests using %s",
-          paste0(interactions$request_matchers, collapse = "/")
+          paste0(matchers, collapse = "/")
         )
+
+        cassette <- current_cassette()
+        interactions <- cassette$http_interactions
         idx <- interactions$find_request(self$request)
         if (!is.na(idx)) {
           vcr_response <- interactions$replay_request(idx)

--- a/R/serialize-interaction.R
+++ b/R/serialize-interaction.R
@@ -3,7 +3,7 @@
 encode_interactions <- function(
   interactions,
   preserve_bytes = FALSE,
-  matchers = c("method", "uri")
+  matchers = "default"
 ) {
   interactions <- lapply(
     interactions,
@@ -40,7 +40,7 @@ decode_interactions <- function(
 encode_interaction <- function(
   interaction,
   preserve_bytes = FALSE,
-  matchers = c("method", "uri")
+  matchers = "default"
 ) {
   list(
     request = encode_request(interaction$request, preserve_bytes, matchers),
@@ -52,12 +52,12 @@ encode_interaction <- function(
 encode_request <- function(
   request,
   preserve_bytes = FALSE,
-  matchers = c("method", "uri")
+  matchers = "default"
 ) {
   compact(list(
     method = request$method,
     uri = encode_uri(request$uri),
-    body = if ("body" %in% matchers || "body_json" %in% matchers) {
+    body = if (any(c("body", "body_json", "default") %in% matchers)) {
       encode_body(request$body, NULL, preserve_bytes)
     },
     headers = if ("headers" %in% matchers) {

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -24,7 +24,11 @@
 #'   * **all**: Never replays recorded interactions, always recording new.
 #'     Useful for re-recording outdated responses or logging all HTTP requests.
 #' @param match_requests_on Character vector of request matchers used to
-#'   determine which recorded HTTP interaction to replay. Possible values are:
+#'   determine which recorded HTTP interaction to replay. The default matches
+#'   on the `"method"`, `"uri"`, and either `"body"` (if present)
+#'   or `"body_json"` (if the content-type is `application/json`).
+#'
+#'   The full set of possible values are:
 #'
 #'   * `method`: the HTTP method.
 #'   * `uri`: the complete request URI, excluding the port.

--- a/R/utils.R
+++ b/R/utils.R
@@ -8,6 +8,9 @@ check_request_matchers <- function(
   if (is.null(x)) {
     return()
   }
+  if (identical(x, "default")) {
+    return()
+  }
   vals <- c(
     "method",
     "uri",

--- a/man/Cassette.Rd
+++ b/man/Cassette.Rd
@@ -25,8 +25,7 @@ function \code{\link[=use_cassette]{use_cassette()}}
 
 \item{\code{serializer}}{(Serializer) serializer (YAML|JSON|QS2)}
 
-\item{\code{match_requests_on}}{(character) matchers to use
-default: method & uri}
+\item{\code{match_requests_on}}{(character) matchers to use}
 
 \item{\code{re_record_interval}}{(numeric) the re-record interval}
 
@@ -88,11 +87,7 @@ is a valid file name.}
 
 \item{\code{record}}{The record mode. Default: "once".}
 
-\item{\code{match_requests_on}}{List of request matchers
-to use to determine what recorded HTTP interaction to replay. Defaults to
-\verb{["method", "uri"]}. The built-in matchers are "method", "uri",
-"headers" and "body" ("host" and "path" not supported yet, but should
-be in a future version)}
+\item{\code{match_requests_on}}{HTTP request components to use when matching.}
 
 \item{\code{serialize_with}}{(character) Which serializer to use.
 Valid values are "yaml" (default), "json", and "qs2".}

--- a/man/insert_cassette.Rd
+++ b/man/insert_cassette.Rd
@@ -39,7 +39,11 @@ Useful for re-recording outdated responses or logging all HTTP requests.
 }}
 
 \item{match_requests_on}{Character vector of request matchers used to
-determine which recorded HTTP interaction to replay. Possible values are:
+determine which recorded HTTP interaction to replay. The default matches
+on the \code{"method"}, \code{"uri"}, and either \code{"body"} (if present)
+or \code{"body_json"} (if the content-type is \code{application/json}).
+
+The full set of possible values are:
 \itemize{
 \item \code{method}: the HTTP method.
 \item \code{uri}: the complete request URI, excluding the port.

--- a/man/insert_example_cassette.Rd
+++ b/man/insert_example_cassette.Rd
@@ -25,11 +25,15 @@ development, (i.e. loaded by devtools) and \code{"none"} otherwise. This makes
 it easy to record during development and ensure that cassettes HTTP
 requests are never made on CRAN.
 
-To re-record all the cassettes, you can delete \verb{inst/_vcr} and run
+To re-record all cassettes, you can delete \verb{inst/_vcr} then run
 \code{pkgdown::build_reference(lazy = FALSE)}.}
 
 \item{match_requests_on}{Character vector of request matchers used to
-determine which recorded HTTP interaction to replay. Possible values are:
+determine which recorded HTTP interaction to replay. The default matches
+on the \code{"method"}, \code{"uri"}, and either \code{"body"} (if present)
+or \code{"body_json"} (if the content-type is \code{application/json}).
+
+The full set of possible values are:
 \itemize{
 \item \code{method}: the HTTP method.
 \item \code{uri}: the complete request URI, excluding the port.

--- a/man/use_cassette.Rd
+++ b/man/use_cassette.Rd
@@ -54,7 +54,11 @@ Useful for re-recording outdated responses or logging all HTTP requests.
 }}
 
 \item{match_requests_on}{Character vector of request matchers used to
-determine which recorded HTTP interaction to replay. Possible values are:
+determine which recorded HTTP interaction to replay. The default matches
+on the \code{"method"}, \code{"uri"}, and either \code{"body"} (if present)
+or \code{"body_json"} (if the content-type is \code{application/json}).
+
+The full set of possible values are:
 \itemize{
 \item \code{method}: the HTTP method.
 \item \code{uri}: the complete request URI, excluding the port.

--- a/man/vcr_configure.Rd
+++ b/man/vcr_configure.Rd
@@ -55,7 +55,11 @@ Useful for re-recording outdated responses or logging all HTTP requests.
 }}
 
 \item{match_requests_on}{Character vector of request matchers used to
-determine which recorded HTTP interaction to replay. Possible values are:
+determine which recorded HTTP interaction to replay. The default matches
+on the \code{"method"}, \code{"uri"}, and either \code{"body"} (if present)
+or \code{"body_json"} (if the content-type is \code{application/json}).
+
+The full set of possible values are:
 \itemize{
 \item \code{method}: the HTTP method.
 \item \code{uri}: the complete request URI, excluding the port.

--- a/tests/testthat/_snaps/request_matcher.md
+++ b/tests/testthat/_snaps/request_matcher.md
@@ -38,3 +38,39 @@
       [Cassette: <none>]       `matching$uri$params$q` is absent
       [Cassette: <none>]       `recorded$uri$params$q` is a character vector ('1')
 
+# default matcher includes body_json
+
+    Code
+      use_cassette("test", httr2::req_perform(req2))
+    Output
+      [Cassette: test] Inserting 'test.yml' (with 1 interactions)
+      [Cassette: test]   Mode: replaying
+      [Cassette: test] Handling request: POST {httpbin}/post
+      [Cassette: test]   Looking for existing requests using method/uri/body_json
+      [Cassette: test]     Request 1: NO MATCH
+      [Cassette: test]       `matching$body$foo`: "baz"
+      [Cassette: test]       `recorded$body$foo`: "bar"
+      [Cassette: test]   No matching requests
+    Condition
+      Error:
+      ! Failed to find matching request in active cassette.
+      i Learn more in `vignette(vcr::debugging)`.
+
+# default matcher includes body
+
+    Code
+      use_cassette("test", httr2::req_perform(req2))
+    Output
+      [Cassette: test] Inserting 'test.yml' (with 1 interactions)
+      [Cassette: test]   Mode: replaying
+      [Cassette: test] Handling request: POST {httpbin}/post foo=baz
+      [Cassette: test]   Looking for existing requests using method/uri/body
+      [Cassette: test]     Request 1: NO MATCH
+      [Cassette: test]       `matching$body`: "foo=baz"
+      [Cassette: test]       `recorded$body`: "foo=bar"
+      [Cassette: test]   No matching requests
+    Condition
+      Error:
+      ! Failed to find matching request in active cassette.
+      i Learn more in `vignette(vcr::debugging)`.
+

--- a/tests/testthat/test-request_matcher.R
+++ b/tests/testthat/test-request_matcher.R
@@ -139,6 +139,40 @@ test_that("can match json bodies", {
   expect_equal(vcr_last_request()$body, list(string = '{"foo":"bar"}'))
 })
 
+
+test_that("default matcher includes body_json", {
+  local_vcr_configure(dir = withr::local_tempdir())
+  local_vcr_configure_log(file = stdout())
+
+  req <- httr2::request(hb("/post"))
+  req1 <- httr2::req_body_json(req, list(foo = "bar"))
+  req2 <- httr2::req_body_json(req, list(foo = "baz"))
+
+  use_cassette("test", httr2::req_perform(req1))
+  expect_snapshot(
+    use_cassette("test", httr2::req_perform(req2)),
+    error = TRUE,
+    transform = \(x) gsub(hb(), "{httpbin}", x, fixed = TRUE),
+  )
+})
+
+test_that("default matcher includes body", {
+  local_vcr_configure(dir = withr::local_tempdir())
+  local_vcr_configure_log(file = stdout())
+
+  req <- httr2::request(hb("/post"))
+  req1 <- httr2::req_body_form(req, foo = "bar")
+  req2 <- httr2::req_body_form(req, foo = "baz")
+
+  use_cassette("test", httr2::req_perform(req1))
+  expect_snapshot(
+    use_cassette("test", httr2::req_perform(req2)),
+    error = TRUE,
+    transform = \(x) gsub(hb(), "{httpbin}", x, fixed = TRUE),
+  )
+})
+
+
 test_that('request matching is not sensitive to escaping special characters', {
   local_vcr_configure(dir = withr::local_tempdir())
   url <- hb("/get?update=2022-01-01T00:00:00&p2=ok")

--- a/tests/testthat/test-serialize-interaction.R
+++ b/tests/testthat/test-serialize-interaction.R
@@ -97,4 +97,10 @@ test_that("header/body only included if needed", {
 
   encoded <- encode_interaction(interaction, matchers = c("method", "uri"))
   expect_named(encoded$request, c("method", "uri"))
+
+  encoded <- encode_interaction(interaction, matchers = "default")
+  expect_named(encoded$request, c("method", "uri", "body"))
+
+  encoded <- encode_interaction(interaction, matchers = "headers")
+  expect_named(encoded$request, c("method", "uri", "headers"))
 })


### PR DESCRIPTION
While using vcr in ellmer, I would consistently forget to set the request matchers. I think this is likely to be a common issue and there's no reason not to eliminate it with a more sophisticated default.
