### PR TITLE
Use own `defer()` everywhere

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ Imports:
     rlang (>= 1.1.0),
     rprojroot,
     waldo,
-    withr,
     yaml
 Suggests:
     crul (>= 1.6.0),
@@ -47,7 +46,8 @@ Suggests:
     rmarkdown,
     roxygen2 (>= 7.2.1),
     testthat (>= 3.0.0),
-    webfakes
+    webfakes,
+    withr
 VignetteBuilder:
     knitr
 Remotes: ropensci/crul

--- a/R/configuration.R
+++ b/R/configuration.R
@@ -201,7 +201,7 @@ vcr_configure <- function(
 #' @inheritParams local_cassette
 local_vcr_configure <- function(..., .frame = parent.frame()) {
   old <- vcr_configure(...)
-  withr::defer(exec(vcr_configure, !!!old), envir = .frame)
+  defer(exec(vcr_configure, !!!old), .frame)
   invisible()
 }
 

--- a/R/lightswitch.R
+++ b/R/lightswitch.R
@@ -65,7 +65,7 @@ turn_off <- function(ignore_cassettes = FALSE) {
 #' @export
 turned_off <- function(code, ignore_cassettes = FALSE) {
   suppressMessages(turn_off(ignore_cassettes = ignore_cassettes))
-  on.exit(turn_on())
+  defer(turn_on())
 
   code
 }

--- a/R/logger.R
+++ b/R/logger.R
@@ -60,7 +60,7 @@ local_vcr_configure_log <- function(
     include_date = include_date,
     log_prefix = log_prefix
   )
-  withr::defer(exec(vcr_configure, !!!old), envir = frame)
+  defer(exec(vcr_configure, !!!old), frame)
 
   invisible()
 }

--- a/R/request_handler-httr.R
+++ b/R/request_handler-httr.R
@@ -14,7 +14,7 @@ RequestHandlerHttr <- R6::R6Class(
     },
     on_ignored_request = function() {
       vcr_httr_mock(FALSE)
-      withr::defer(vcr_httr_mock(TRUE))
+      defer(vcr_httr_mock(TRUE))
 
       httr_perform(self$request_original)
     },
@@ -25,7 +25,7 @@ RequestHandlerHttr <- R6::R6Class(
 
     on_recordable_request = function() {
       vcr_httr_mock(FALSE)
-      withr::defer(vcr_httr_mock(TRUE))
+      defer(vcr_httr_mock(TRUE))
 
       response <- httr_perform(self$request_original)
 

--- a/R/use_cassette.R
+++ b/R/use_cassette.R
@@ -239,7 +239,7 @@ local_cassette <- function(
     warn_on_empty = warn_on_empty
   )
   if (!is.null(cassette)) {
-    withr::defer(eject_cassette(), envir = frame)
+    defer(eject_cassette(), frame)
   }
 
   invisible(cassette)

--- a/R/utils.R
+++ b/R/utils.R
@@ -82,16 +82,6 @@ pkg_versions <- function() {
 # for mocking
 Sys.time <- NULL
 
-parse_http_date <- function(x) {
-  check_string(x)
-
-  withr::local_locale(LC_TIME = "C")
-  # https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1
-  out <- as.POSIXct(strptime(x, "%a, %d %b %Y %H:%M:%S", tz = "UTC"))
-  attr(out, "tzone") <- NULL
-  out
-}
-
 cat_line <- function(...) {
   cat(paste0(..., "\n", collapse = ""))
 }
@@ -121,4 +111,9 @@ hz_namez <- function(x) {
   } else {
     !(is.na(nms) | nms == "")
   }
+}
+
+defer <- function(expr, env = caller_env(), after = FALSE) {
+  thunk <- as.call(list(function() expr))
+  do.call(on.exit, list(thunk, TRUE, after), envir = env)
 }

--- a/tests/testthat/helper-vcr.R
+++ b/tests/testthat/helper-vcr.R
@@ -1,6 +1,6 @@
 local_light_switch <- function(frame = parent.frame()) {
   old <- the$light_switch
-  withr::defer(the$light_switch <- old, envir = frame)
+  defer(the$light_switch <- old, frame)
 }
 
 desc_text <- "Package: %s

--- a/tests/testthat/test-ause_cassette_record_modes.R
+++ b/tests/testthat/test-ause_cassette_record_modes.R
@@ -127,8 +127,8 @@ test_that("record mode: all", {
   expect_lt(interactions_1[[1]]$recorded_at, interactions_2[[1]]$recorded_at)
   # and request is re-perf
   expect_lt(
-    parse_http_date(res1$response_headers$date),
-    parse_http_date(res2$response_headers$date)
+    httr::parse_http_date(res1$response_headers$date),
+    httr::parse_http_date(res2$response_headers$date)
   )
 
   # new interactions are recorded


### PR DESCRIPTION
I can't see how this would make a different, but we might as well clean up and eliminate as a potential problem. (And it means we can drop one dependency)
