### PR TITLE
Fix VCR examples for VCR off

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vcr
 Title: Record 'HTTP' Calls to Disk
-Version: 2.0.0
+Version: 2.1.1.91
 Authors@R: c(
     person("Scott", "Chamberlain", , "myrmecocystus@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1444-9135")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,7 @@ Config/testthat/start-first: ause_cassette_re_record
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 X-schema.org-applicationCategory: Web
 X-schema.org-isPartOf: https://ropensci.org
 X-schema.org-keywords: http, https, API, web-services, curl, mock,

--- a/R/cassettes.R
+++ b/R/cassettes.R
@@ -56,6 +56,10 @@ insert_cassette <- function(
 #' @export
 #' @rdname insert_cassette
 eject_cassette <- function() {
+  if (vcr_turned_off()) {
+    return(invisible())
+  }
+
   if (!cassette_active()) {
     cli::cli_abort("No cassette in use.")
   }

--- a/R/examples.R
+++ b/R/examples.R
@@ -42,6 +42,9 @@ insert_example_cassette <- function(
   preserve_exact_body_bytes = NULL,
   re_record_interval = NULL
 ) {
+  if (vcr_turned_off()) {
+    return(invisible())
+  }
   dir <- example_cassette_path(package)
   in_dev <- is_dev_package(package)
   if (is.null(record)) {

--- a/man/insert_example_cassette.Rd
+++ b/man/insert_example_cassette.Rd
@@ -76,7 +76,7 @@ replayed during \verb{R CMD check}, ensuring that your example no longer uses
 the internet.
 }
 \examples{
-\dontshow{if (requireNamespace("httr2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+\dontshow{if (requireNamespace("httr2")) withAutoprint(\{ # examplesIf}
 # In this example I'm showing the insert and eject commands, but you'd
 # usually wrap these in \dontshow{} so the user doesn't see them and
 # think that they're something they need to copy.

--- a/man/vcr-package.Rd
+++ b/man/vcr-package.Rd
@@ -65,7 +65,7 @@ Authors:
 
 Other contributors:
 \itemize{
-  \item rOpenSci (019jywm96) [funder]
+  \item rOpenSci (\href{https://ror.org/019jywm96}{ROR}) [funder]
 }
 
 }

--- a/tests/testthat/_snaps/lightswitch.md
+++ b/tests/testthat/_snaps/lightswitch.md
@@ -5,7 +5,7 @@
     Message
       vcr turned off; see ?turn_on to turn vcr back on
 
-# turned_off works iif no cassettes active
+# turned_off works if and only if no cassettes active
 
     Code
       turned_off(5 + 5)

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -1,0 +1,22 @@
+test_that("insert_example_cassette works as expected", {
+  withr::with_envvar(new = c("VCR_TURN_OFF" = "true"), {
+    # Reinitialize the lightswitch to pick up the new env var
+    the$light_switch <- lightswitch_init()
+
+    # Verify VCR is actually turned off
+    expect_true(vcr_turned_off())
+
+    # insert_example_cassette shouldn't actually create a file
+    # under this test scenario
+    inserted_cas <- insert_example_cassette("fiz-baz", package = "vcr")
+    req <- httr2::request("https://hb.cran.dev/get")
+    resp <- httr2::req_perform(req)
+    ejected_cas <- eject_cassette()
+
+    expect_null(inserted_cas)
+    expect_null(ejected_cas)
+  })
+
+  # reset the$light_switch
+  the$light_switch <- lightswitch_init()
+})

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -9,7 +9,7 @@ test_that("insert_example_cassette works as expected", {
     # insert_example_cassette shouldn't actually create a file
     # under this test scenario
     inserted_cas <- insert_example_cassette("fiz-baz", package = "vcr")
-    req <- httr2::request("https://hb.cran.dev/get")
+    req <- httr2::request(hb("/get"))
     resp <- httr2::req_perform(req)
     ejected_cas <- eject_cassette()
 


### PR DESCRIPTION
cc @drmowinckels

This is not tested and not enough. 

When I try to run examples that use vcr when VCR is off, I get the error:

```r
Error in `cassette$file()`:
! attempt to apply non-function
```

from https://github.com/ropensci/vcr/blob/42fad406bf43519ffa535ee2316082339fc3bbf8/R/examples.R#L61C3-L61C26 

So some earlier escaping is needed.

But a remaining problem is that if no cassette is inserted, `vcr::eject_cassette()` errors.

In `local_cassette()`, the ejecting function is called conditionally. https://github.com/ropensci/vcr/blob/42fad406bf43519ffa535ee2316082339fc3bbf8/R/use_cassette.R#L146

Maybe `vcr::eject_cassette()` should also have an early `return()` when vcr is off? Thoughts?