### PR TITLE
potential fix for delete fxn when type = tests

### DIFF
--- a/R/delete_cassettes.R
+++ b/R/delete_cassettes.R
@@ -78,17 +78,7 @@ delete_cassettes <- function(
 delete_type_cassettes <- function(type, prefix) {
   dir <- switch(
     type,
-    tests = {
-      path <- cassette_path()
-      if (is.null(path)) {
-        cli::cli_abort(c(
-          "No cassette directory has been configured.",
-          i = "Call {.fn vcr_configure} or {.fn local_vcr_configure} with a {.arg dir} argument before using {.fn delete_cassettes}.",
-          i = "Example: {.code vcr_configure(dir = \"tests/testthat/_vcr\")}"
-        ))
-      }
-      path
-    },
+    tests = test_cassette_dir(),
     examples = file.path(rprojroot::find_package_root_file(), "inst", "_vcr"),
     vignettes = file.path(
       rprojroot::find_package_root_file(),
@@ -128,4 +118,16 @@ delete_type_cassettes <- function(type, prefix) {
   })
 
   deleted
+}
+
+test_cassette_dir <- function() {
+  path <- cassette_path()
+  if (is.null(path)) {
+    cli::cli_abort(c(
+      "No cassette directory has been configured.",
+      i = "Call {.fn vcr_configure} or {.fn local_vcr_configure} with a {.arg dir} argument before using {.fn delete_cassettes}.",
+      i = "Example: {.code vcr_configure(dir = \"tests/testthat/_vcr\")}"
+    ))
+  }
+  path
 }

--- a/R/delete_cassettes.R
+++ b/R/delete_cassettes.R
@@ -78,7 +78,17 @@ delete_cassettes <- function(
 delete_type_cassettes <- function(type, prefix) {
   dir <- switch(
     type,
-    tests = cassette_path(),
+    tests = {
+      path <- cassette_path()
+      if (is.null(path)) {
+        cli::cli_abort(c(
+          "No cassette directory has been configured.",
+          i = "Call {.fn vcr_configure} or {.fn local_vcr_configure} with a {.arg dir} argument before using {.fn delete_cassettes}.",
+          i = "Example: {.code vcr_configure(dir = \"tests/testthat/_vcr\")}"
+        ))
+      }
+      path
+    },
     examples = file.path(rprojroot::find_package_root_file(), "inst", "_vcr"),
     vignettes = file.path(
       rprojroot::find_package_root_file(),

--- a/tests/testthat/_snaps/delete_cassettes.md
+++ b/tests/testthat/_snaps/delete_cassettes.md
@@ -61,6 +61,16 @@
       Directory '<inst_vcr>' does not exist. Nothing to delete.
       No cassettes matching prefix "test" were found.
 
+# delete_cassettes() errors when no cassette directory is configured
+
+    Code
+      delete_cassettes("api-", type = "tests")
+    Condition
+      Error in `FUN()`:
+      ! No cassette directory has been configured.
+      i Call `vcr_configure()` or `local_vcr_configure()` with a `dir` argument before using `delete_cassettes()`.
+      i Example: `vcr_configure(dir = "tests/testthat/_vcr")`
+
 # delete_cassettes() informs when no cassettes match prefix
 
     Code

--- a/tests/testthat/_snaps/delete_cassettes.md
+++ b/tests/testthat/_snaps/delete_cassettes.md
@@ -66,7 +66,7 @@
     Code
       delete_cassettes("api-", type = "tests")
     Condition
-      Error in `FUN()`:
+      Error in `test_cassette_dir()`:
       ! No cassette directory has been configured.
       i Call `vcr_configure()` or `local_vcr_configure()` with a `dir` argument before using `delete_cassettes()`.
       i Example: `vcr_configure(dir = "tests/testthat/_vcr")`

--- a/tests/testthat/test-delete_cassettes.R
+++ b/tests/testthat/test-delete_cassettes.R
@@ -187,6 +187,14 @@ test_that("delete_cassettes() informs when directory doesn't exist", {
   expect_identical(result, character(0))
 })
 
+test_that("delete_cassettes() errors when no cassette directory is configured", {
+  local_vcr_configure(dir = NULL)
+
+  expect_snapshot(error = TRUE, {
+    delete_cassettes("api-", type = "tests")
+  })
+})
+
 test_that("delete_cassettes() informs when no cassettes match prefix", {
   dir <- withr::local_tempdir()
   local_vcr_configure(dir = dir)


### PR DESCRIPTION
- if `cassette_path` gives `NULL` abort with message
- add small test to cover this use case

Thoughts?

The way this came up was that I was in a package of mine that uses `vcr` and I loaded vcr then tried to run `delete_cassettes("some-pattern")` and did not get a helpful error:

```r
Error in `dir.exists()`:
! invalid filename argument
```

Hopefully this makes sense?

This I think only matters when trying to delete cassettes in tests directories