### PR TITLE
Up minimum required R version to match `{yaml12}`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ URL: https://github.com/ropensci/vcr/,
     https://docs.ropensci.org/vcr/
 BugReports: https://github.com/ropensci/vcr/issues
 Depends:
-    R (>= 4.1)
+    R (>= 4.2)
 Imports:
     cli,
     curl (>= 6.3.0),


### PR DESCRIPTION
I recently had a Github Actions run fail on a windows R4.1 machine for my package `{etn}` because `{yaml12}` requires R4.2. By adopting this dependency all packages dependent on vcr now also require R4.2 as a minimum. 

In this PR I just document this change in DESCRIPTION.
